### PR TITLE
feat(mcp): my_team prompt surfaces the prediction-market read (0.4.1)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudinho/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Claudinho CLI — the 2026 men's football tournament in your terminal: live scores, fixtures, group tables, prediction-market odds. Not affiliated with FIFA or Anthropic.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudinho/core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Domain model, provider adapters, standings, and a read-only market-signal sidecar for Claudinho — the 2026 men's football tournament. Not affiliated with FIFA or Anthropic.",
   "type": "module",
   "license": "MIT",

--- a/packages/mcp/mcpb/manifest.json
+++ b/packages/mcp/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "claudinho",
   "display_name": "Claudinho ⚽",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Live scores, fixtures, and group standings for the 2026 men's football tournament. Not affiliated with FIFA or Anthropic.",
   "long_description": "Ask Claude about the 2026 men's football tournament — live scores, today's fixtures, a team's next match, group standings, and read-only prediction-market odds (informational only, not betting advice). Facts and emoji flags only; no logos, crests, or footage. An independent, open-source fan project. Not affiliated with or endorsed by FIFA or Anthropic.",
   "author": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudinho/mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Claudinho MCP server — ask your agent about the 2026 men's football tournament: live scores, fixtures, standings, prediction-market odds. Not affiliated with FIFA or Anthropic.",
   "type": "module",
   "license": "MIT",

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -256,7 +256,7 @@ export function buildServer(): McpServer {
     'my_team',
     {
       title: 'My team',
-      description: "Focus on one team's next match and group situation.",
+      description: "Focus on one team's next match, group situation, and the prediction-market read.",
       argsSchema: { team: teamArg.describe('3-letter team code, e.g. MEX') },
     },
     ({ team }) => ({
@@ -265,7 +265,7 @@ export function buildServer(): McpServer {
           role: 'user',
           content: {
             type: 'text',
-            text: `Using get_next_fixture and get_standings, tell me about ${team}'s next match in the 2026 tournament and their current group standing.`,
+            text: `Using get_next_fixture, get_standings, and get_market_signal, tell me about ${team}'s next match in the 2026 tournament, their current group standing, and what prediction markets currently say about that match. Treat the market percentages as informational context only — relay them factually, never as betting or trading advice.`,
           },
         },
       ],

--- a/packages/mcp/test/prompts.test.ts
+++ b/packages/mcp/test/prompts.test.ts
@@ -1,0 +1,47 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { describe, expect, it } from 'vitest';
+import { buildServer } from '../src/server';
+
+/** Drive the real MCP protocol so prompts are checked as clients see them. */
+async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  const server = buildServer();
+  await server.connect(serverT);
+  const client = new Client({ name: 'prompts-test', version: '0.0.0' });
+  await client.connect(clientT);
+  try {
+    return await fn(client);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+const promptText = (res: { messages: { content: { type: string; text?: string } }[] }) =>
+  res.messages.map((m) => (m.content.type === 'text' ? (m.content.text ?? '') : '')).join('\n');
+
+describe('my_team prompt', () => {
+  it('guides the agent through fixture, standings, AND the market read', async () => {
+    await withClient(async (client) => {
+      const res = await client.getPrompt({ name: 'my_team', arguments: { team: 'MEX' } });
+      const text = promptText(res);
+      expect(text).toContain('get_next_fixture');
+      expect(text).toContain('get_standings');
+      expect(text).toContain('get_market_signal');
+      expect(text).toContain('MEX');
+    });
+  });
+
+  it('frames market data as informational only, with an explicit anti-advice guardrail', async () => {
+    await withClient(async (client) => {
+      const res = await client.getPrompt({ name: 'my_team', arguments: { team: 'BRA' } });
+      const text = promptText(res);
+      expect(text).toMatch(/informational/i);
+      // The guardrail itself names betting/trading in a prohibition ("never as
+      // betting or trading advice") — assert that negation is present, not that
+      // the word is absent.
+      expect(text).toMatch(/never[^.]*\b(betting|trading)\b/i);
+    });
+  });
+});


### PR DESCRIPTION
## What

The `my_team` MCP prompt routed only through `get_next_fixture` + `get_standings`, so the prediction-market read never surfaced — `/my_team MEX` showed fixture + standings but no odds, even though a live Polymarket market exists for that fixture.

It now also calls **`get_market_signal`**, framed **informational-only** ("…never as betting or trading advice"). No tool changes — just the prompt's guidance (so `get_next_fixture` stays pure-static).

## Why

User-reported: invoking `my_team MEX` didn't mention markets. Markets only ride on surfaces that already hit the network (`today`/`match`), the dedicated `get_market_signal`, and `share`. Adding the market tool to this prompt closes the "tell me about my team's next match" gap without changing any tool's static nature or the hot-path rules.

## Tests
New `packages/mcp/test/prompts.test.ts` (protocol-level `getPrompt`): asserts the prompt names the three tools + the team code, and that the **anti-advice guardrail** ("never … betting/trading") + "informational" framing are present.

261 tests green (core 117, mcp 37, cli 107) · build · typecheck · lint clean · frozen lockfile verified.

Lockstep **0.4.1** (publish.yml gates tag == all package versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
