### PR TITLE
fix: matchday QA from the opener (0.4.3)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,10 +20,11 @@ npx @claudinho/cli today
 ```bash
 claudinho today [date]      # a day's fixtures in your timezone (default: today), live scores inline
 claudinho live              # matches in play right now
-claudinho next <TEAM>       # a team's next fixture + countdown   (e.g. next MEX)
+claudinho next [TEAM]       # a team's next fixture + countdown (default: $CLAUDINHO_TEAM)
 claudinho table [GROUP]     # group standings (default: all groups)
 claudinho match <id>        # a single match's detail
 claudinho markets [target]  # prediction-market signals: today | <date> | <id> | next <TEAM>
+                            #   (next prefers the team's IN-PLAY match while one is live)
 claudinho share [target]    # copy-pasteable match snippet: today | live | <date> | <id> | next <TEAM>
 claudinho prompt            # one compact status line (for statusline/tmux/Starship)
 claudinho init-statusline   # wire it into the Claude Code statusline
@@ -77,7 +78,7 @@ market-implied percentages — for a date, a match, or a team's next fixture:
 claudinho markets                 # today's signals
 claudinho markets 2026-06-11      # a specific date
 claudinho markets 760415          # one match by id
-claudinho markets next MEX        # a team's next fixture
+claudinho markets next MEX        # a team's current-or-next fixture (in-play preferred)
 claudinho markets today --json    # structured sidecar output
 ```
 
@@ -91,11 +92,12 @@ Opt out with `--no-markets` (per command) or `CLAUDINHO_MARKETS=off` (global). T
 statusline and hook **never** show market data — it stays off the hot path.
 
 > **How matches are matched:** event slugs are derived automatically from each
-> fixture (`fifwc-{home}-{away}-{date}`), so real odds appear for any match with a
+> fixture (`fifwc-{home}-{away}-{date}`), so real signals appear for any match with a
 > live Polymarket market — no mapping needed (`mapping.2026.json` is for slug
 > *overrides* only). Matching fails closed, so an unmatched fixture simply shows
-> nothing. For an offline preview, set `CLAUDINHO_MARKETS_SOURCE=fake` to render
-> clearly-labeled synthetic **"demo data"** odds.
+> nothing — and finished matches never show one (market signals are pre-match
+> and in-play reads). For an offline preview, set `CLAUDINHO_MARKETS_SOURCE=fake`
+> to render clearly-labeled synthetic **"demo data"** signals.
 
 ## Shareable snippets
 
@@ -157,7 +159,7 @@ The statusline reads from a local micro-cache and **never blocks on the
 network** (<150ms). When several matches are live it shows them all inline:
 `⚽ 🇳🇴 1–1 🇫🇷 87' · 🇸🇳 1–2 🇮🇶 86'`. Customize via env:
 
-- `CLAUDINHO_TEAM=MEX` — show only your team's match
+- `CLAUDINHO_TEAM=MEX` — show only your team's match; also the default team for `next`, `markets next`, and `share next` when the argument is omitted
 - `CLAUDINHO_MAX=2` — cap how many live matches show inline (rest collapse to `+N`; default: all)
 - `CLAUDINHO_COMPACT=0` — show 3-letter codes alongside flags
 

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -13,6 +13,7 @@ import {
   getMatchById,
   groups,
   hasSaneDistribution,
+  isFinished,
   isReliableMarketSignal,
   isValidDate,
   isValidTimeZone,
@@ -452,12 +453,17 @@ export async function cmdMatch(id: string, ctx: Ctx): Promise<void> {
   precheck(cfg, t);
   // ±1-day window fetch: the provider buckets scoreboard days in its own zone,
   // so fetching only the fixture's UTC date can miss its live/final state.
-  const { match, source: liveSource } = await getMatchById(adapterFor(ctx), id);
+  const { match, degraded, source: liveSource } = await getMatchById(adapterFor(ctx), id);
 
   const marketSignal = match ? await reliableMarketSignalFor(ctx, match) : undefined;
 
   if (cfg.json) {
-    emitJson({ match: match ?? null, source: liveSource ?? null, marketSignal: marketSignal ?? null });
+    emitJson({
+      degraded,
+      match: match ?? null,
+      source: liveSource ?? null,
+      marketSignal: marketSignal ?? null,
+    });
     return;
   }
 
@@ -518,9 +524,12 @@ function marketHeaderLine(m: Match, cfg: CliConfig): string {
 
 /** Null-signal line, specific about finished matches (market reads are pre-match). */
 function noSignalLine(m: Match, now: Date): string {
-  return marketRelevant(m, now)
-    ? 'No market signal for this match.'
-    : 'Match has finished — market signals are pre-match and in-play reads.';
+  if (marketRelevant(m, now)) return 'No market signal for this match.';
+  // "has finished" only when a live overlay confirmed it; a static fixture
+  // whose window merely lapsed gets the honest, hedged variant.
+  return isFinished(m.status)
+    ? 'Match has finished — market signals are pre-match and in-play reads.'
+    : 'Match appears to have finished — market signals are pre-match and in-play reads.';
 }
 
 function printMarketBlock(m: Match, sig: MarketSignal, c: Painter): void {
@@ -551,7 +560,10 @@ export async function cmdMarkets(
     precheck(cfg, t);
     const code = resolveTeamArg(team, 'Usage: claudinho markets next <team> (or set CLAUDINHO_TEAM)');
     const now = ctx.now ?? new Date();
-    const fixture = currentOrNextFixtureForTeam(code, { from: now });
+    const base = currentOrNextFixtureForTeam(code, { from: now });
+    // Live overlay so an early FT ends relevance (and extra time extends it) —
+    // the static fixture's status is forever SCHEDULED.
+    const fixture = base ? ((await getMatchById(adapterFor(ctx), base.id)).match ?? base) : undefined;
     const sig =
       fixture && marketRelevant(fixture, now)
         ? (await marketSignalsFor(ctx, [fixture], MARKETS_CMD_OPTS)).get(fixture.id)
@@ -586,7 +598,8 @@ export async function cmdMarkets(
   if (target && target !== 'today' && !isValidDate(target)) {
     precheck(cfg, t);
     const now = ctx.now ?? new Date();
-    const match = allFixtures().find((m) => m.id === target);
+    // Live overlay (±1-day window) so FT gates the resolved market correctly.
+    const { match } = await getMatchById(adapterFor(ctx), target);
     const sig =
       match && marketRelevant(match, now)
         ? (await marketSignalsFor(ctx, [match], MARKETS_CMD_OPTS)).get(match.id)
@@ -615,10 +628,10 @@ export async function cmdMarkets(
   // markets [today | <date>]
   const explicitDate = target && target !== 'today' ? target : undefined;
   precheck(cfg, t, explicitDate);
-  const date = explicitDate ?? localDate(new Date().toISOString(), cfg.tz);
+  const now = ctx.now ?? new Date();
+  const date = explicitDate ?? localDate(now.toISOString(), cfg.tz);
   const { matches } = await getMatchesForDate(adapterFor(ctx), date);
   const todays = fixturesByDate(date, matches, cfg.tz);
-  const now = ctx.now ?? new Date();
   const relevant = todays.filter((m) => marketRelevant(m, now));
   const signals = await marketSignalsFor(ctx, relevant, MARKETS_CMD_OPTS);
   const rows = relevant

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -2,12 +2,15 @@ import {
   allFixtures,
   computeStandings,
   countdown,
+  currentOrNextFixtureForTeam,
+  DEFAULT_COMPETITION,
   fixturesByDate,
   fixturesByGroup,
   formatDate,
   formatKickoff,
   formatShareSnippet,
   getMarketSignals,
+  getMatchById,
   groups,
   hasSaneDistribution,
   isReliableMarketSignal,
@@ -17,6 +20,7 @@ import {
   makeMarketProvider,
   marketBlock,
   marketLine,
+  marketRelevant,
   matchFlavor,
   matchLocation,
   nextFixtureForTeam,
@@ -53,7 +57,7 @@ import type {
   ShareStyle,
 } from '@claudinho/core';
 import { readCurrentState } from './cache';
-import { renderPrompt } from './statusline';
+import { liveMatchesFromCache, renderPrompt } from './statusline';
 import { renderHook } from './hook';
 import { runRefresh, shouldRefresh, spawnRefresh } from './refresh';
 import { initHook, initStatusline } from './install';
@@ -70,6 +74,8 @@ type Ctx = {
   marketProvider?: MarketProvider;
   /** Injection seam for `share --copy` so tests never touch the real clipboard. */
   copy?: (text: string) => boolean;
+  /** Injection seam for time-dependent gates (market relevance, live windows). */
+  now?: Date;
 };
 
 /** The injected adapter, or one constructed from the configured source. */
@@ -130,8 +136,12 @@ async function reliableMarketSignals(
   matches: Match[],
 ): Promise<Map<string, MarketSignal>> {
   if (ctx.cfg.markets === false) return new Map();
-  const raw = await marketSignalsFor(ctx, matches, DEFAULT_ON_MARKET_OPTS);
-  const now = new Date();
+  const now = ctx.now ?? new Date();
+  // Market reads are pre-match/in-play artifacts: never fetch (or show) them
+  // for finished matches — "markets favor X" after full time reads as a bug.
+  const relevant = matches.filter((m) => marketRelevant(m, now));
+  if (relevant.length === 0) return new Map();
+  const raw = await marketSignalsFor(ctx, relevant, DEFAULT_ON_MARKET_OPTS);
   const out = new Map<string, MarketSignal>();
   for (const [id, s] of raw) if (isReliableMarketSignal(s, { now })) out.set(id, s);
   return out;
@@ -165,9 +175,30 @@ function precheck(cfg: CliConfig, t: Translator, date?: string): void {
   if (cfg.tz && !isValidTimeZone(cfg.tz)) {
     process.stderr.write(t('warn.tz', { tz: cfg.tz }) + '\n');
   }
+  // Config-drift guard: a leftover CLAUDINHO_COMPETITION (e.g. from
+  // pre-tournament testing) silently points the live fetch at a different
+  // competition than the bundled schedule — fixtures render, scores never
+  // arrive. Warn loudly on user-facing commands; never on the statusline/hook
+  // hot path (those must stay single-line and silent).
+  const competition = resolveCompetition();
+  if (competition !== DEFAULT_COMPETITION) {
+    process.stderr.write(
+      `claudinho: CLAUDINHO_COMPETITION=${competition} — live data follows a different competition than the bundled 2026 schedule.\n`,
+    );
+  }
   if (date !== undefined && !isValidDate(date)) {
     throw new InputError(t('err.date', { date }));
   }
+}
+
+/**
+ * Resolve an optional team argument, falling back to CLAUDINHO_TEAM — the same
+ * env the statusline/hook already honor, so "my team" is configured once.
+ */
+function resolveTeamArg(team: string | undefined, usage: string): string {
+  const code = team ?? process.env.CLAUDINHO_TEAM;
+  if (!code) throw new InputError(usage);
+  return code.toUpperCase();
 }
 
 /** `claudinho today [date]` */
@@ -239,10 +270,10 @@ export async function cmdLive(ctx: Ctx): Promise<void> {
   out(disclaimer(t, c));
 }
 
-/** `claudinho next <team>` */
-export async function cmdNext(team: string, { cfg, t }: Ctx): Promise<void> {
+/** `claudinho next [team]` (team defaults to CLAUDINHO_TEAM) */
+export async function cmdNext(team: string | undefined, { cfg, t }: Ctx): Promise<void> {
   precheck(cfg, t);
-  const code = team.toUpperCase();
+  const code = resolveTeamArg(team, 'Usage: claudinho next <team> (or set CLAUDINHO_TEAM)');
   const fixture = nextFixtureForTeam(code);
 
   if (cfg.json) {
@@ -419,18 +450,9 @@ export function cmdInitHook(opts: { print?: boolean }, { cfg }: Ctx): void {
 export async function cmdMatch(id: string, ctx: Ctx): Promise<void> {
   const { cfg, t } = ctx;
   precheck(cfg, t);
-  const adapter = adapterFor(ctx);
-  let match = allFixtures().find((m) => m.id === id);
-  let liveSource: string | undefined;
-  try {
-    if (match) {
-      const live = await adapter.fetchByDate(match.kickoff.slice(0, 10));
-      match = live.find((m) => m.id === id) ?? match;
-      liveSource = adapter.name;
-    }
-  } catch {
-    /* keep static */
-  }
+  // ±1-day window fetch: the provider buckets scoreboard days in its own zone,
+  // so fetching only the fixture's UTC date can miss its live/final state.
+  const { match, source: liveSource } = await getMatchById(adapterFor(ctx), id);
 
   const marketSignal = match ? await reliableMarketSignalFor(ctx, match) : undefined;
 
@@ -483,8 +505,22 @@ function marketDisplayable(sig: MarketSignal): boolean {
   return !sig.ambiguous && sig.favorite != null && hasSaneDistribution(sig.outcomes);
 }
 
-function marketHeaderLine(m: Match): string {
-  return `${m.home.flag} ${m.home.name} vs ${m.away.name} ${m.away.flag}`;
+/**
+ * Header for a market read. Includes the kickoff date — "South Korea (Jun 18)"
+ * and "South Africa (today)" are one skim apart, and a dated header is what
+ * stops a reader (or an agent) conflating a future fixture's read with the
+ * match being played right now.
+ */
+function marketHeaderLine(m: Match, cfg: CliConfig): string {
+  const when = formatDate(m.kickoff, { tz: cfg.tz, locale: cfg.lang });
+  return `${m.home.flag} ${m.home.name} vs ${m.away.name} ${m.away.flag} · ${when}`;
+}
+
+/** Null-signal line, specific about finished matches (market reads are pre-match). */
+function noSignalLine(m: Match, now: Date): string {
+  return marketRelevant(m, now)
+    ? 'No market signal for this match.'
+    : 'Match has finished — market signals are pre-match and in-play reads.';
 }
 
 function printMarketBlock(m: Match, sig: MarketSignal, c: Painter): void {
@@ -508,15 +544,18 @@ export async function cmdMarkets(
 ): Promise<void> {
   const { cfg, t } = ctx;
 
-  // markets next <team>
+  // markets next <team> — prefers the team's IN-PLAY match when one is live:
+  // mid-match, "what do markets say about MEX" means the match being played,
+  // not next week's (whose thin market would gate to an empty answer).
   if (target === 'next') {
     precheck(cfg, t);
-    if (!team) throw new InputError('Usage: claudinho markets next <team>');
-    const code = team.toUpperCase();
-    const fixture = nextFixtureForTeam(code);
-    const sig = fixture
-      ? (await marketSignalsFor(ctx, [fixture], MARKETS_CMD_OPTS)).get(fixture.id)
-      : undefined;
+    const code = resolveTeamArg(team, 'Usage: claudinho markets next <team> (or set CLAUDINHO_TEAM)');
+    const now = ctx.now ?? new Date();
+    const fixture = currentOrNextFixtureForTeam(code, { from: now });
+    const sig =
+      fixture && marketRelevant(fixture, now)
+        ? (await marketSignalsFor(ctx, [fixture], MARKETS_CMD_OPTS)).get(fixture.id)
+        : undefined;
     const shown = sig && marketDisplayable(sig) ? sig : undefined;
     if (cfg.json) {
       emitJson({
@@ -532,10 +571,10 @@ export async function cmdMarkets(
     if (!fixture) {
       out(c.dim('  ' + t('next.none', { team: code })));
     } else {
-      out(header(marketHeaderLine(fixture), c));
+      out(header(marketHeaderLine(fixture, cfg), c));
       out();
       if (shown) printMarketBlock(fixture, shown, c);
-      else out(c.dim('    No market signal for this match.'));
+      else out(c.dim('    ' + noSignalLine(fixture, now)));
     }
     out();
     out(disclaimer(t, c));
@@ -546,10 +585,12 @@ export async function cmdMarkets(
   // markets <id>  (anything that isn't a date or the "today" keyword)
   if (target && target !== 'today' && !isValidDate(target)) {
     precheck(cfg, t);
+    const now = ctx.now ?? new Date();
     const match = allFixtures().find((m) => m.id === target);
-    const sig = match
-      ? (await marketSignalsFor(ctx, [match], MARKETS_CMD_OPTS)).get(match.id)
-      : undefined;
+    const sig =
+      match && marketRelevant(match, now)
+        ? (await marketSignalsFor(ctx, [match], MARKETS_CMD_OPTS)).get(match.id)
+        : undefined;
     const shown = sig && marketDisplayable(sig) ? sig : undefined;
     if (cfg.json) {
       emitJson({ matchId: target, informationalOnly: true, signal: shown ?? null });
@@ -560,10 +601,10 @@ export async function cmdMarkets(
     if (!match) {
       out(c.dim('  ' + t('match.none', { id: target })));
     } else {
-      out(header(marketHeaderLine(match), c));
+      out(header(marketHeaderLine(match, cfg), c));
       out();
       if (shown) printMarketBlock(match, shown, c);
-      else out(c.dim('    No market signal for this match.'));
+      else out(c.dim('    ' + noSignalLine(match, now)));
     }
     out();
     out(disclaimer(t, c));
@@ -577,8 +618,10 @@ export async function cmdMarkets(
   const date = explicitDate ?? localDate(new Date().toISOString(), cfg.tz);
   const { matches } = await getMatchesForDate(adapterFor(ctx), date);
   const todays = fixturesByDate(date, matches, cfg.tz);
-  const signals = await marketSignalsFor(ctx, todays, MARKETS_CMD_OPTS);
-  const rows = todays
+  const now = ctx.now ?? new Date();
+  const relevant = todays.filter((m) => marketRelevant(m, now));
+  const signals = await marketSignalsFor(ctx, relevant, MARKETS_CMD_OPTS);
+  const rows = relevant
     .map((m) => ({ match: m, signal: signals.get(m.id) }))
     .filter(
       (r): r is { match: Match; signal: MarketSignal } =>
@@ -600,7 +643,7 @@ export async function cmdMarkets(
     out(c.dim(`  No market signals available for ${date}.`));
   } else {
     for (const { match, signal } of rows) {
-      out('  ' + c.bold(marketHeaderLine(match)));
+      out('  ' + c.bold(marketHeaderLine(match, cfg)));
       printMarketBlock(match, signal, c);
       out();
     }
@@ -737,8 +780,7 @@ export async function cmdShare(
   // share next <team>
   if (target === 'next') {
     precheck(cfg, t);
-    if (!team) throw new InputError('Usage: claudinho share next <team>');
-    const code = team.toUpperCase();
+    const code = resolveTeamArg(team, 'Usage: claudinho share next <team> (or set CLAUDINHO_TEAM)');
     const fixture = nextFixtureForTeam(code);
     const matches = fixture ? [fixture] : [];
     const signals = await reliableShareSignals(ctx, matches);
@@ -772,18 +814,9 @@ export async function cmdShare(
   // share <id>  (anything that isn't a date or the "today" keyword)
   if (target && target !== 'today' && !isValidDate(target)) {
     precheck(cfg, t);
-    const adapter = adapterFor(ctx);
-    let match = allFixtures().find((m) => m.id === target);
-    let source: string | undefined;
-    try {
-      if (match) {
-        const live = await adapter.fetchByDate(match.kickoff.slice(0, 10));
-        match = live.find((m) => m.id === target) ?? match;
-        source = adapter.name;
-      }
-    } catch {
-      /* keep static */
-    }
+    // ±1-day window fetch (see cmdMatch): the provider's scoreboard day can
+    // differ from the fixture's UTC date.
+    const { match, source } = await getMatchById(adapterFor(ctx), target);
     const matches = match ? [match] : [];
     const signals = await reliableShareSignals(ctx, matches);
     emitShare(
@@ -840,9 +873,11 @@ export async function cmdShare(
 }
 
 /**
- * `vibe` — a tiny, offline easter egg. Prints a random matchday-coder one-liner
- * signed with the project's social tag. No network, no cache, no i18n: the
- * Spanglish is the joke. #VibingLaVidaLoca
+ * `vibe` — a tiny easter egg. Prints a random matchday-coder one-liner signed
+ * with the project's social tag. No network and no i18n (the Spanglish is the
+ * joke); a best-effort COLD cache read (never the hot path) lets the line nod
+ * to a live score, and the static schedule flavors opening/final day.
+ * #VibingLaVidaLoca
  */
 const VIBES = [
   'Shipping code, watching goals.',
@@ -854,17 +889,64 @@ const VIBES = [
   'Stoppage time and a clean stack trace.',
   'Coding into extra time.',
 ];
+const VIBES_OPENER = [
+  'Day one of the tournament. Save your work — it’s about to get loud.',
+  'Opening day: fresh bracket, fresh branch.',
+];
+const VIBES_FINAL = [
+  'Final day. One last build, one last whistle.',
+  'Ship it before the trophy does.',
+];
+
+/**
+ * The live-score segment for a vibe line, e.g. "🇰🇷 1–1 🇨🇿 69'". Prefers the
+ * CLAUDINHO_TEAM match, else the first live match; undefined when nothing is
+ * live. Pure — exported for tests.
+ */
+export function vibeLiveSegment(live: Match[], team?: string): string | undefined {
+  const code = team?.toUpperCase();
+  const pick =
+    (code && live.find((m) => m.home.code === code || m.away.code === code)) ?? live[0];
+  if (!pick) return undefined;
+  const minute = pick.status === 'HT' ? 'HT' : pick.minute ? `${pick.minute}'` : 'LIVE';
+  return `${pick.home.flag} ${scoreline(pick)} ${pick.away.flag} ${minute}`;
+}
+
+/** The vibe pool for a local date: opener/final days mix in themed lines. */
+export function vibePool(todayLocal: string, fixtures: Match[] = allFixtures()): string[] {
+  let first: string | undefined;
+  let last: string | undefined;
+  for (const m of fixtures) {
+    const d = m.kickoff.slice(0, 10);
+    if (!first || d < first) first = d;
+    if (!last || d > last) last = d;
+  }
+  if (todayLocal === first) return [...VIBES, ...VIBES_OPENER];
+  if (todayLocal === last) return [...VIBES, ...VIBES_FINAL];
+  return VIBES;
+}
 
 export function cmdVibe(ctx: Ctx): void {
   const { cfg } = ctx;
-  const line = VIBES[Math.floor(Math.random() * VIBES.length)];
+  const pool = vibePool(localDate((ctx.now ?? new Date()).toISOString(), cfg.tz));
+  const line = pool[Math.floor(Math.random() * pool.length)];
+  let liveSeg: string | undefined;
+  try {
+    const state = readCurrentState(cfg.source, resolveCompetition());
+    liveSeg = vibeLiveSegment(
+      liveMatchesFromCache(state, (ctx.now ?? new Date()).getTime()),
+      process.env.CLAUDINHO_TEAM,
+    );
+  } catch {
+    // The easter egg stays harmless: any cache problem → plain vibe.
+  }
   if (cfg.json) {
-    emitJson({ vibe: line, tag: '#VibingLaVidaLoca' });
+    emitJson({ vibe: line, tag: '#VibingLaVidaLoca', ...(liveSeg ? { live: liveSeg } : {}) });
     return;
   }
   const c = painterFor(cfg);
   out();
-  out('  ⚽ ' + c.bold(line));
+  out('  ⚽ ' + (liveSeg ? `${liveSeg} — ` : '') + c.bold(line ?? ''));
   out('  ' + c.cyan('#VibingLaVidaLoca'));
   out();
 }

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -2,7 +2,6 @@ import {
   allFixtures,
   computeStandings,
   countdown,
-  currentOrNextFixtureForTeam,
   DEFAULT_COMPETITION,
   fixturesByDate,
   fixturesByGroup,
@@ -20,6 +19,7 @@ import {
   localDate,
   makeMarketProvider,
   marketBlock,
+  marketFixtureForTeam,
   marketLine,
   marketRelevant,
   matchFlavor,
@@ -560,10 +560,9 @@ export async function cmdMarkets(
     precheck(cfg, t);
     const code = resolveTeamArg(team, 'Usage: claudinho markets next <team> (or set CLAUDINHO_TEAM)');
     const now = ctx.now ?? new Date();
-    const base = currentOrNextFixtureForTeam(code, { from: now });
-    // Live overlay so an early FT ends relevance (and extra time extends it) —
-    // the static fixture's status is forever SCHEDULED.
-    const fixture = base ? ((await getMatchById(adapterFor(ctx), base.id)).match ?? base) : undefined;
+    // Live-confirmed selection: handles extra time past the static window AND
+    // early FTs inside it (the static fixture's status is forever SCHEDULED).
+    const { match: fixture } = await marketFixtureForTeam(adapterFor(ctx), code, now);
     const sig =
       fixture && marketRelevant(fixture, now)
         ? (await marketSignalsFor(ctx, [fixture], MARKETS_CMD_OPTS)).get(fixture.id)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -55,7 +55,10 @@ const program = new Command();
 
 program
   .name('claudinho')
-  .description('The 2026 football tournament in your terminal.\n' + DISCLAIMER)
+  .description(
+    'The 2026 men’s football tournament in your terminal, your Claude Code statusline, and any MCP client.\n' +
+      DISCLAIMER,
+  )
   .version(VERSION, '-v, --version')
   .option('--lang <code>', 'language: en, es, pt, fr')
   .option('--tz <zone>', 'IANA timezone, e.g. America/Mexico_City')
@@ -63,7 +66,7 @@ program
   .option('--no-color', 'disable ANSI colors')
   .option('--source <name>', 'live data provider (advanced)')
   .option('--flavor <level>', 'commentary flair: off, subtle, full (default: full)')
-  .option('--no-markets', 'hide prediction-market signals (informational odds)');
+  .option('--no-markets', 'hide prediction-market signals (informational only)');
 
 program.addHelpText('after', '\n#VibingLaVidaLoca ⚽');
 
@@ -93,7 +96,7 @@ program
 program
   .command('next')
   .description("show a team's next fixture")
-  .argument('<team>', 'team code, e.g. MEX')
+  .argument('[team]', 'team code, e.g. MEX (default: $CLAUDINHO_TEAM)')
   .action(async (team, _opts, cmd) => {
     try {
       await cmdNext(team, ctxFrom(cmd));
@@ -130,7 +133,7 @@ program
   .command('markets')
   .description('show prediction-market signals (read-only, informational only)')
   .argument('[target]', 'date (YYYY-MM-DD), match id, "today", or "next"')
-  .argument('[team]', 'team code when target is "next" (e.g. MEX)')
+  .argument('[team]', 'team code when target is "next" (default: $CLAUDINHO_TEAM)')
   .action(async (target, team, _opts, cmd) => {
     try {
       await cmdMarkets(target, team, ctxFrom(cmd));
@@ -143,7 +146,7 @@ program
   .command('share')
   .description('print a shareable, copy-pasteable match snippet (#VibingLaVidaLoca)')
   .argument('[target]', '"today" (default), "live", a date, a match id, or "next"')
-  .argument('[team]', 'team code when target is "next" (e.g. MEX)')
+  .argument('[team]', 'team code when target is "next" (default: $CLAUDINHO_TEAM)')
   .option('--style <style>', 'snippet style: social (default) or compact')
   .option('--copy', 'also copy the snippet to the clipboard (best-effort)')
   .option('--no-hashtag', 'omit the #VibingLaVidaLoca tag')

--- a/packages/cli/src/statusline.ts
+++ b/packages/cli/src/statusline.ts
@@ -9,15 +9,18 @@ import {
   allFixtures,
   byKickoff,
   countdown,
+  fixturesInLiveWindow,
   isLive,
+  LIVE_WINDOW_MS,
   nextFixtureForTeam,
   scoreline,
   type Match,
 } from '@claudinho/core';
 import { ageMs, type CacheState } from './cache';
 
-/** A fixture is potentially live from kickoff until ~kickoff + 140 min. */
-export const LIVE_WINDOW_MS = 140 * 60_000;
+// The live-window constant lives in core (shared with the market-relevance
+// gate); re-exported here so existing call sites keep importing from this file.
+export { LIVE_WINDOW_MS };
 /** Don't display cached live scores older than this (avoid stale scores). */
 export const DISPLAY_STALE_MS = 5 * 60_000;
 /** Refresh the cache when it's older than this during a live window. */
@@ -25,11 +28,7 @@ export const LIVE_TTL_MS = 15_000;
 
 /** Are we inside a potential live window for any fixture? (cheap, static) */
 export function inLiveWindow(now = Date.now(), fixtures: Match[] = allFixtures()): boolean {
-  for (const m of fixtures) {
-    const k = Date.parse(m.kickoff);
-    if (now >= k && now <= k + LIVE_WINDOW_MS) return true;
-  }
-  return false;
+  return fixturesInLiveWindow(now, fixtures).length > 0;
 }
 
 /** The soonest upcoming fixture across the whole tournament. */
@@ -101,6 +100,26 @@ export function renderPrompt(state: CacheState | undefined, opts: PromptOpts = {
     const overflow = live.length - shown.length;
     if (overflow > 0) line += ` +${overflow}`;
     return line;
+  }
+
+  // Cold/stale cache during a live window: a countdown here is actively
+  // misleading — a match is on, and the static schedule alone tells us that.
+  // Say "live · syncing" until the refresher lands a snapshot. A FRESH snapshot
+  // with no live matches is trusted as-is (per the feed nothing is in play —
+  // early FT, delay, postponement) and falls through to the countdown.
+  const cacheFresh = !!state && ageMs(state, nowMs) < DISPLAY_STALE_MS;
+  if (!cacheFresh) {
+    const win = fixturesInLiveWindow(nowMs).filter(
+      (m) => !team || m.home.code === team || m.away.code === team,
+    );
+    const first = win[0];
+    if (first) {
+      const more = win.length - 1;
+      return (
+        `⚽ ${first.home.flag} vs ${first.away.flag} live · syncing…` +
+        (more > 0 ? ` +${more}` : '')
+      );
+    }
   }
 
   // Nothing (relevant) live → next-fixture countdown (pure static).

--- a/packages/cli/src/statusline.ts
+++ b/packages/cli/src/statusline.ts
@@ -104,10 +104,13 @@ export function renderPrompt(state: CacheState | undefined, opts: PromptOpts = {
 
   // Cold/stale cache during a live window: a countdown here is actively
   // misleading — a match is on, and the static schedule alone tells us that.
-  // Say "live · syncing" until the refresher lands a snapshot. A FRESH snapshot
-  // with no live matches is trusted as-is (per the feed nothing is in play —
-  // early FT, delay, postponement) and falls through to the countdown.
-  const cacheFresh = !!state && ageMs(state, nowMs) < DISPLAY_STALE_MS;
+  // Say "live · syncing" until the refresher lands a snapshot. A FRESH,
+  // NON-DEGRADED snapshot with no live matches is trusted as-is (per the feed
+  // nothing is in play — early FT, delay, postponement) and falls through to
+  // the countdown; a degraded snapshot means "the fetch failed", not "the
+  // feed said empty", so it must not bring the countdown back mid-match.
+  const cacheFresh =
+    !!state && state.degraded !== true && ageMs(state, nowMs) < DISPLAY_STALE_MS;
   if (!cacheFresh) {
     const win = fixturesInLiveWindow(nowMs).filter(
       (m) => !team || m.home.code === team || m.away.code === team,

--- a/packages/cli/test/markets.test.ts
+++ b/packages/cli/test/markets.test.ts
@@ -22,18 +22,29 @@ const fakeAdapter: ProviderAdapter = {
   },
 };
 
-/** A synthesizing market provider with a fixed clock (deterministic). */
-const synth = () =>
-  new FakeMarketProvider({ synthesize: true, now: new Date('2026-06-13T12:00:00Z') });
+/**
+ * Fixed clock for every time-dependent gate (market relevance, live windows) —
+ * keeps the suite deterministic forever, including after the tournament ends
+ * (when every fixture's live window is in the real past).
+ */
+const TEST_NOW = new Date('2026-06-13T12:00:00Z');
+
+/** A synthesizing market provider with the same fixed clock (deterministic). */
+const synth = () => new FakeMarketProvider({ synthesize: true, now: TEST_NOW });
+
+/** A fixture still upcoming at TEST_NOW (its market read is relevant). */
+const upcoming = (): Match =>
+  allFixtures().find((m) => Date.parse(m.kickoff) > TEST_NOW.getTime())!;
 
 function cfg(over: Partial<CliConfig> = {}): CliConfig {
   return { lang: 'en', tz: 'UTC', json: true, color: false, source: 'espn', flavor: 'off', ...over };
 }
-const ctx = (over: Partial<CliConfig>, marketProvider: MarketProvider) => ({
+const ctx = (over: Partial<CliConfig>, marketProvider: MarketProvider, now: Date = TEST_NOW) => ({
   cfg: cfg(over),
   t: makeT('en'),
   adapter: fakeAdapter,
   marketProvider,
+  now,
 });
 
 const outSpy = vi.spyOn(process.stdout, 'write');
@@ -98,7 +109,7 @@ describe('cmdMarkets — date listing', () => {
 
 describe('cmdMarkets — single match', () => {
   it('returns the signal for a known match id', async () => {
-    const id = allFixtures()[0]!.id;
+    const id = upcoming().id;
     await cmdMarkets(id, undefined, ctx({ json: true }, synth()));
     const data = json() as { matchId: string; signal: { source: string; matchId: string } | null };
     expect(data.matchId).toBe(id);
@@ -110,20 +121,57 @@ describe('cmdMarkets — single match', () => {
     await cmdMarkets('does-not-exist', undefined, ctx({ json: true }, synth()));
     expect(json().signal).toBeNull();
   });
+
+  it('suppresses the signal for a finished match (market reads are pre-match)', async () => {
+    // The tournament opener is long past at this clock.
+    const opener = allFixtures()[0]!;
+    const after = new Date(Date.parse(opener.kickoff) + 6 * 60 * 60_000);
+    await cmdMarkets(opener.id, undefined, ctx({ json: true }, synth(), after));
+    expect(json().signal).toBeNull();
+
+    await cmdMarkets(opener.id, undefined, ctx({ json: false }, synth(), after));
+    expect(text()).toContain('market signals are pre-match and in-play reads');
+  });
 });
 
 describe('cmdMarkets — next <team>', () => {
-  it('throws InputError when the team is missing', async () => {
-    await expect(cmdMarkets('next', undefined, ctx({}, synth()))).rejects.toBeInstanceOf(
-      InputError,
-    );
+  it('throws InputError when the team is missing and CLAUDINHO_TEAM is unset', async () => {
+    const prev = process.env.CLAUDINHO_TEAM;
+    delete process.env.CLAUDINHO_TEAM;
+    try {
+      await expect(cmdMarkets('next', undefined, ctx({}, synth()))).rejects.toBeInstanceOf(
+        InputError,
+      );
+    } finally {
+      if (prev !== undefined) process.env.CLAUDINHO_TEAM = prev;
+    }
+  });
+
+  it('falls back to CLAUDINHO_TEAM when the team argument is omitted', async () => {
+    const prev = process.env.CLAUDINHO_TEAM;
+    process.env.CLAUDINHO_TEAM = upcoming().home.code.toLowerCase();
+    try {
+      await cmdMarkets('next', undefined, ctx({ json: true }, synth()));
+      expect((json() as { team: string }).team).toBe(upcoming().home.code.toUpperCase());
+    } finally {
+      if (prev === undefined) delete process.env.CLAUDINHO_TEAM;
+      else process.env.CLAUDINHO_TEAM = prev;
+    }
   });
 
   it('echoes the team and an informational-only flag', async () => {
-    const team = allFixtures()[0]!.home.code;
+    const team = upcoming().home.code;
     await cmdMarkets('next', team, ctx({ json: true }, synth()));
     const data = json() as { team: string; informationalOnly: boolean };
     expect(data.team).toBe(team);
     expect(data.informationalOnly).toBe(true);
+  });
+
+  it("prefers the team's IN-PLAY match over their next fixture", async () => {
+    // Mid-opener clock: the first fixture is being played right now.
+    const opener = allFixtures()[0]!;
+    const during = new Date(Date.parse(opener.kickoff) + 30 * 60_000);
+    await cmdMarkets('next', opener.home.code, ctx({ json: true }, synth(), during));
+    expect((json() as { matchId: string }).matchId).toBe(opener.id);
   });
 });

--- a/packages/cli/test/statusline.test.ts
+++ b/packages/cli/test/statusline.test.ts
@@ -145,6 +145,13 @@ describe('renderPrompt — live window, cold/stale cache → "syncing"', () => {
     expect(renderPrompt(s, { now: NOW })).toContain(' in ');
   });
 
+  it('does NOT trust a fresh DEGRADED snapshot — syncing, not countdown', () => {
+    // The refresher writes { live: [], degraded: true } with a fresh timestamp
+    // when the fetch fails; that means "fetch failed", not "feed said empty".
+    const s = { ...state([]), degraded: true };
+    expect(renderPrompt(s, { now: NOW })).toContain('live · syncing');
+  });
+
   it('applies the team filter: syncing only for a team in a window', () => {
     expect(renderPrompt(undefined, { now: NOW, team: 'MEX' })).toContain('live · syncing');
     expect(renderPrompt(undefined, { now: NOW, team: 'BRA' })).toContain(' in ');

--- a/packages/cli/test/statusline.test.ts
+++ b/packages/cli/test/statusline.test.ts
@@ -126,3 +126,27 @@ describe('inLiveWindow', () => {
     expect(inLiveWindow(new Date('2026-06-01T00:00:00Z').getTime())).toBe(false);
   });
 });
+
+describe('renderPrompt — live window, cold/stale cache → "syncing"', () => {
+  // NOW sits inside the real opener\'s live window (KO 2026-06-11T19:00Z).
+  it('says "live · syncing" instead of a countdown when the cache is missing', () => {
+    const line = renderPrompt(undefined, { now: NOW });
+    expect(line).toContain('live · syncing');
+    expect(line).not.toContain(' in ');
+  });
+
+  it('says "syncing" when the cache is STALE during the window', () => {
+    const s = state([], '2026-06-11T19:30:00Z'); // 30 min old → stale
+    expect(renderPrompt(s, { now: NOW })).toContain('live · syncing');
+  });
+
+  it('trusts a FRESH empty cache (feed says nothing live) → countdown', () => {
+    const s = state([]); // fresh timestamp, no live matches
+    expect(renderPrompt(s, { now: NOW })).toContain(' in ');
+  });
+
+  it('applies the team filter: syncing only for a team in a window', () => {
+    expect(renderPrompt(undefined, { now: NOW, team: 'MEX' })).toContain('live · syncing');
+    expect(renderPrompt(undefined, { now: NOW, team: 'BRA' })).toContain(' in ');
+  });
+});

--- a/packages/cli/test/teamDefault.test.ts
+++ b/packages/cli/test/teamDefault.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { allFixtures, type Match, type ProviderAdapter } from '@claudinho/core';
+import { cmdNext, cmdShare, InputError } from '../src/commands';
+import type { CliConfig } from '../src/config';
+import { makeT } from '../src/i18n';
+
+const fakeAdapter: ProviderAdapter = {
+  name: 'fake',
+  capabilities: { push: false, latencyHintSec: 0 },
+  async fetchByDate(): Promise<Match[]> {
+    return [];
+  },
+  async fetchLive(): Promise<Match[]> {
+    return [];
+  },
+};
+
+function cfg(over: Partial<CliConfig> = {}): CliConfig {
+  return { lang: 'en', tz: 'UTC', json: true, color: false, source: 'espn', flavor: 'off', markets: false, ...over };
+}
+const ctx = () => ({ cfg: cfg(), t: makeT('en'), adapter: fakeAdapter });
+
+const outSpy = vi.spyOn(process.stdout, 'write');
+let writes: string[] = [];
+beforeEach(() => {
+  writes = [];
+  outSpy.mockImplementation((c: unknown) => {
+    writes.push(String(c));
+    return true;
+  });
+});
+afterEach(() => outSpy.mockReset());
+const json = () => JSON.parse(writes.join(''));
+
+describe('CLAUDINHO_TEAM fallback (next / share next)', () => {
+  const TEAM = allFixtures()[0]!.home.code;
+  let prev: string | undefined;
+  beforeEach(() => {
+    prev = process.env.CLAUDINHO_TEAM;
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.CLAUDINHO_TEAM;
+    else process.env.CLAUDINHO_TEAM = prev;
+  });
+
+  it('cmdNext falls back to the env team', async () => {
+    process.env.CLAUDINHO_TEAM = TEAM.toLowerCase();
+    await cmdNext(undefined, ctx());
+    expect((json() as { team: string }).team).toBe(TEAM.toUpperCase());
+  });
+
+  it('cmdNext still errors with no arg and no env', async () => {
+    delete process.env.CLAUDINHO_TEAM;
+    await expect(cmdNext(undefined, ctx())).rejects.toBeInstanceOf(InputError);
+  });
+
+  it('cmdShare next falls back to the env team', async () => {
+    process.env.CLAUDINHO_TEAM = TEAM;
+    await cmdShare('next', undefined, {}, ctx());
+    expect((json() as { team: string }).team).toBe(TEAM.toUpperCase());
+  });
+});

--- a/packages/cli/test/vibeMatchday.test.ts
+++ b/packages/cli/test/vibeMatchday.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { Match } from '@claudinho/core';
+import { vibeLiveSegment, vibePool } from '../src/commands';
+
+function m(id: string, home: [string, string], away: [string, string], over: Partial<Match> = {}): Match {
+  return {
+    id,
+    stage: 'GROUP',
+    group: 'A',
+    kickoff: '2026-06-11T19:00Z',
+    venue: 'X',
+    home: { code: home[0], name: home[0], flag: home[1] },
+    away: { code: away[0], name: away[0], flag: away[1] },
+    status: 'LIVE',
+    updatedAt: '2026-06-11T20:00:00Z',
+    ...over,
+  };
+}
+
+describe('vibeLiveSegment', () => {
+  const live = [
+    m('1', ['MEX', '🇲🇽'], ['RSA', '🇿🇦'], { score: { home: 1, away: 0 }, minute: 67 }),
+    m('2', ['BRA', '🇧🇷'], ['MAR', '🇲🇦'], { score: { home: 2, away: 1 }, minute: 70 }),
+  ];
+
+  it('is undefined when nothing is live', () => {
+    expect(vibeLiveSegment([])).toBeUndefined();
+  });
+
+  it('shows the first live match with score and minute', () => {
+    expect(vibeLiveSegment(live)).toBe("🇲🇽 1–0 🇿🇦 67'");
+  });
+
+  it('prefers the CLAUDINHO_TEAM match (case-insensitive)', () => {
+    expect(vibeLiveSegment(live, 'bra')).toBe("🇧🇷 2–1 🇲🇦 70'");
+  });
+
+  it('marks halftime as HT', () => {
+    expect(vibeLiveSegment([m('1', ['MEX', '🇲🇽'], ['RSA', '🇿🇦'], { status: 'HT', score: { home: 0, away: 0 } })])).toBe(
+      '🇲🇽 0–0 🇿🇦 HT',
+    );
+  });
+});
+
+describe('vibePool', () => {
+  const fixtures = [
+    m('first', ['MEX', '🇲🇽'], ['RSA', '🇿🇦'], { kickoff: '2026-06-11T19:00Z' }),
+    m('mid', ['BRA', '🇧🇷'], ['MAR', '🇲🇦'], { kickoff: '2026-06-13T22:00Z' }),
+    m('last', ['TBD', '🏳️'], ['TBD', '🏳️'], { kickoff: '2026-07-19T19:00Z' }),
+  ];
+
+  it('mixes opener lines in on the first day only', () => {
+    expect(vibePool('2026-06-11', fixtures).length).toBeGreaterThan(
+      vibePool('2026-06-13', fixtures).length,
+    );
+  });
+
+  it('mixes final-day lines in on the last day', () => {
+    const finals = vibePool('2026-07-19', fixtures);
+    expect(finals.some((l) => /final/i.test(l))).toBe(true);
+  });
+
+  it('is the plain pool on an ordinary day', () => {
+    const plain = vibePool('2026-06-13', fixtures);
+    expect(plain.some((l) => /opening|final/i.test(l))).toBe(false);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ export {
   getMatchesForDate,
   getLiveMatches,
   getMatchById,
+  marketFixtureForTeam,
   resolveCompetition,
   liveSourceLabel,
 } from './live';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,9 @@ export {
   fixturesByTeam,
   fixturesByGroup,
   nextFixtureForTeam,
+  currentOrNextFixtureForTeam,
+  fixturesInLiveWindow,
+  LIVE_WINDOW_MS,
   groups,
 } from './schedule';
 
@@ -36,10 +39,11 @@ export {
   mergeLive,
   getMatchesForDate,
   getLiveMatches,
+  getMatchById,
   resolveCompetition,
   liveSourceLabel,
 } from './live';
-export type { LiveResult } from './live';
+export type { LiveResult, MatchByIdResult } from './live';
 export { DEFAULT_COMPETITION, competitionBase } from './adapters/espn';
 
 // Prediction-market signals (read-only sidecar; never embedded in Match).
@@ -61,6 +65,7 @@ export {
   hasSaneDistribution,
   isStaleSignal,
   isReliableMarketSignal,
+  marketRelevant,
   buildMarketSignal,
   DEFAULT_MAX_AGE_MS,
 } from './markets/normalize';

--- a/packages/core/src/live.ts
+++ b/packages/core/src/live.ts
@@ -96,6 +96,43 @@ function shiftUtcDate(dateISO: string, days: number): string {
     .slice(0, 10);
 }
 
+export interface MatchByIdResult {
+  match?: Match;
+  degraded: boolean;
+  source?: string;
+}
+
+/**
+ * A single match by id, with live overlay. The provider's scoreboard buckets
+ * days in its own zone (ESPN: US/Eastern), so a fixture's UTC date can differ
+ * from the scoreboard day it's filed under — a 02:00Z kickoff belongs to the
+ * previous ET evening, and fetching only the UTC date silently misses its live
+ * state (the match then renders from the static schedule as if scheduled).
+ * Fetch the ±1-day window around the fixture's UTC date instead — the same
+ * trick `getMatchesForDate` uses — and fall back to the static fixture on any
+ * provider error.
+ */
+export async function getMatchById(
+  adapter: ProviderAdapter,
+  id: string,
+): Promise<MatchByIdResult> {
+  const base = allFixtures().find((m) => m.id === id);
+  if (!base) return { match: undefined, degraded: false };
+  const day = base.kickoff.slice(0, 10);
+  try {
+    const live = adapter.fetchWindow
+      ? await adapter.fetchWindow(shiftUtcDate(day, -1), shiftUtcDate(day, 1))
+      : await adapter.fetchByDate(day);
+    return {
+      match: live.find((m) => m.id === id) ?? base,
+      degraded: false,
+      source: adapter.name,
+    };
+  } catch {
+    return { match: base, degraded: true };
+  }
+}
+
 /** Currently-live matches; empty + degraded on error. */
 export async function getLiveMatches(adapter: ProviderAdapter): Promise<LiveResult> {
   try {

--- a/packages/core/src/live.ts
+++ b/packages/core/src/live.ts
@@ -5,7 +5,8 @@
  */
 import { competitionBase, DEFAULT_COMPETITION, EspnAdapter } from './adapters/espn';
 import type { ProviderAdapter } from './adapters/types';
-import { allFixtures } from './schedule';
+import { isFinished } from './normalize';
+import { allFixtures, fixturesByTeam, LIVE_WINDOW_MS, nextFixtureForTeam } from './schedule';
 import type { Match } from './types';
 
 /**
@@ -100,6 +101,45 @@ export interface MatchByIdResult {
   match?: Match;
   degraded: boolean;
   source?: string;
+}
+
+/**
+ * Extra slack past the static live window for team-query candidate selection:
+ * a knockout match in extra time + penalties runs to ~kickoff + 180 min, well
+ * past LIVE_WINDOW_MS (140). The slack only widens which fixture we *check*
+ * with a live overlay — the overlay's status, not the clock, then decides.
+ */
+const EXTRA_TIME_SLACK_MS = 60 * 60_000;
+
+/**
+ * The fixture a team-scoped MARKET query should be about, live-confirmed.
+ * Static window math alone fails twice at the edges: a match in extra time
+ * (now > kickoff + 140min, still LIVE) would be skipped for next week's
+ * fixture, and a just-finished match (inside the window, already FT) would be
+ * selected over the next one. So: pick the in-window candidate using a widened
+ * window, overlay live state, and fall through to the next fixture when the
+ * overlay says the candidate is finished. Degraded fetches keep the static
+ * candidate (fail-closed: the market-relevance gate then errs toward showing
+ * nothing rather than something wrong).
+ */
+export async function marketFixtureForTeam(
+  adapter: ProviderAdapter,
+  code: string,
+  now: Date = new Date(),
+): Promise<MatchByIdResult> {
+  const nowMs = now.getTime();
+  const candidate = fixturesByTeam(code).find((m) => {
+    const k = Date.parse(m.kickoff);
+    return nowMs >= k && nowMs <= k + LIVE_WINDOW_MS + EXTRA_TIME_SLACK_MS;
+  });
+  if (candidate) {
+    const r = await getMatchById(adapter, candidate.id);
+    const m = r.match ?? candidate;
+    if (!isFinished(m.status)) return { ...r, match: m };
+    // Confirmed finished → the team's market story has moved on.
+  }
+  const next = nextFixtureForTeam(code, { from: now });
+  return { match: next, degraded: false };
 }
 
 /**

--- a/packages/core/src/live.ts
+++ b/packages/core/src/live.ts
@@ -123,11 +123,11 @@ export async function getMatchById(
     const live = adapter.fetchWindow
       ? await adapter.fetchWindow(shiftUtcDate(day, -1), shiftUtcDate(day, 1))
       : await adapter.fetchByDate(day);
-    return {
-      match: live.find((m) => m.id === id) ?? base,
-      degraded: false,
-      source: adapter.name,
-    };
+    const hit = live.find((m) => m.id === id);
+    // Attribute the provider only when live data actually served the match —
+    // a static fixture rendered after a successful-but-missing fetch is not
+    // "Live data: ESPN".
+    return { match: hit ?? base, degraded: false, source: hit ? adapter.name : undefined };
   } catch {
     return { match: base, degraded: true };
   }

--- a/packages/core/src/markets/normalize.ts
+++ b/packages/core/src/markets/normalize.ts
@@ -3,7 +3,7 @@
  * the single primitive every default-on surface keys off: "show only when
  * reliable, otherwise omit silently."
  */
-import { isFinished } from '../normalize';
+import { isFinished, isLive } from '../normalize';
 import { LIVE_WINDOW_MS } from '../schedule';
 import type { Match } from '../types';
 import type {
@@ -25,6 +25,10 @@ export const DEFAULT_MAX_AGE_MS = 15 * 60_000;
  * An unparseable kickoff fails open (the reliability gate still applies).
  */
 export function marketRelevant(match: Match, now: Date = new Date()): boolean {
+  // A live overlay outranks the time window in BOTH directions: a match in
+  // extra time runs past kickoff+140min and its in-play read stays legitimate,
+  // while an early FT ends relevance before the window does.
+  if (isLive(match.status)) return true;
   if (isFinished(match.status)) return false;
   const k = Date.parse(match.kickoff);
   return !Number.isFinite(k) || now.getTime() <= k + LIVE_WINDOW_MS;

--- a/packages/core/src/markets/normalize.ts
+++ b/packages/core/src/markets/normalize.ts
@@ -3,6 +3,8 @@
  * the single primitive every default-on surface keys off: "show only when
  * reliable, otherwise omit silently."
  */
+import { isFinished } from '../normalize';
+import { LIVE_WINDOW_MS } from '../schedule';
 import type { Match } from '../types';
 import type {
   FavoriteStrength,
@@ -14,6 +16,19 @@ import type {
 
 /** Default freshness window: a signal older than this is stale (15 minutes). */
 export const DEFAULT_MAX_AGE_MS = 15 * 60_000;
+
+/**
+ * Market signals are pre-match and in-play reads. Once a match has finished —
+ * status `FT`, or (for static fixtures that never get a live overlay) once its
+ * live window has long passed — a "favorite" is resolved history: showing
+ * "markets favor X 100%" after full time reads as a bug, not information.
+ * An unparseable kickoff fails open (the reliability gate still applies).
+ */
+export function marketRelevant(match: Match, now: Date = new Date()): boolean {
+  if (isFinished(match.status)) return false;
+  const k = Date.parse(match.kickoff);
+  return !Number.isFinite(k) || now.getTime() <= k + LIVE_WINDOW_MS;
+}
 
 /**
  * Re-scale outcome probabilities so the positive ones sum to 1. This removes

--- a/packages/core/src/schedule.ts
+++ b/packages/core/src/schedule.ts
@@ -60,6 +60,42 @@ export function nextFixtureForTeam(
   );
 }
 
+/** A fixture is potentially live from kickoff until ~kickoff + 140 min. */
+export const LIVE_WINDOW_MS = 140 * 60_000;
+
+/** Fixtures whose live window contains `now` (cheap, static — no network). */
+export function fixturesInLiveWindow(
+  now = Date.now(),
+  fixtures: Match[] = SCHEDULE,
+): Match[] {
+  return fixtures
+    .filter((m) => {
+      const k = Date.parse(m.kickoff);
+      return now >= k && now <= k + LIVE_WINDOW_MS;
+    })
+    .sort(byKickoff);
+}
+
+/**
+ * The team's in-play fixture when one is inside its live window, else the next
+ * upcoming fixture. This is "the match that matters for <team> right now":
+ * mid-match, a user (or an agent) asking about a team almost always means the
+ * one being played — `nextFixtureForTeam` alone would skip it the moment the
+ * kickoff is in the past and silently answer about next week.
+ */
+export function currentOrNextFixtureForTeam(
+  code: string,
+  opts: { from?: Date; fixtures?: Match[] } = {},
+): Match | undefined {
+  const from = opts.from ?? new Date();
+  const nowMs = from.getTime();
+  const inPlay = fixturesByTeam(code, opts.fixtures ?? SCHEDULE).find((m) => {
+    const k = Date.parse(m.kickoff);
+    return nowMs >= k && nowMs <= k + LIVE_WINDOW_MS;
+  });
+  return inPlay ?? nextFixtureForTeam(code, opts);
+}
+
 /** Sorted list of distinct group letters present in the schedule. */
 export function groups(fixtures: Match[] = SCHEDULE): string[] {
   const set = new Set<string>();

--- a/packages/core/test/matchday.test.ts
+++ b/packages/core/test/matchday.test.ts
@@ -72,6 +72,17 @@ describe('marketRelevant', () => {
   it('fails open on an unparseable kickoff (the reliability gate still applies)', () => {
     expect(marketRelevant(fx('bad', 'not-a-date'), new Date())).toBe(true);
   });
+
+  it('stays relevant for a LIVE overlay past the window (extra time, knockouts)', () => {
+    const et = fx('et', a.kickoff, { status: 'LIVE', minute: 117 });
+    const deepIntoEt = new Date(Date.parse(a.kickoff) + LIVE_WINDOW_MS + 20 * 60_000);
+    expect(marketRelevant(et, deepIntoEt)).toBe(true);
+  });
+
+  it('ends relevance on an EARLY live FT even inside the window', () => {
+    const earlyFt = fx('eft', a.kickoff, { status: 'FT', score: { home: 1, away: 0 } });
+    expect(marketRelevant(earlyFt, new Date(Date.parse(a.kickoff) + 100 * 60_000))).toBe(false);
+  });
 });
 
 describe('getMatchById', () => {

--- a/packages/core/test/matchday.test.ts
+++ b/packages/core/test/matchday.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+  allFixtures,
   currentOrNextFixtureForTeam,
   fixturesInLiveWindow,
   getMatchById,
   LIVE_WINDOW_MS,
+  marketFixtureForTeam,
   marketRelevant,
   type Match,
   type ProviderAdapter,
@@ -158,5 +160,58 @@ describe('getMatchById', () => {
     const r = await getMatchById(adapter, 'nope');
     expect(r.match).toBeUndefined();
     expect(called).toBe(false);
+  });
+});
+
+describe('marketFixtureForTeam (live-confirmed selection)', () => {
+  // Uses the real bundled schedule: the opener + the home team's later fixture.
+  const opener = allFixtures()[0]!;
+  const team = opener.home.code;
+
+  function adapterReturning(overlay: Match[] | 'throw'): ProviderAdapter {
+    return {
+      name: 'fake',
+      capabilities: { push: false, latencyHintSec: 0 },
+      async fetchByDate() {
+        if (overlay === 'throw') throw new Error('down');
+        return overlay;
+      },
+      async fetchWindow() {
+        if (overlay === 'throw') throw new Error('down');
+        return overlay;
+      },
+      async fetchLive() {
+        return [];
+      },
+    };
+  }
+
+  it('keeps an extra-time LIVE match even past the 140-minute window', async () => {
+    const deepEt = new Date(Date.parse(opener.kickoff) + LIVE_WINDOW_MS + 20 * 60_000);
+    const live = { ...opener, status: 'LIVE' as const, minute: 117, score: { home: 1, away: 1 } };
+    const r = await marketFixtureForTeam(adapterReturning([live]), team, deepEt);
+    expect(r.match?.id).toBe(opener.id);
+    expect(r.match?.status).toBe('LIVE');
+  });
+
+  it('falls through to the NEXT fixture when the candidate is confirmed FT', async () => {
+    const during = new Date(Date.parse(opener.kickoff) + 110 * 60_000);
+    const ft = { ...opener, status: 'FT' as const, score: { home: 2, away: 0 } };
+    const r = await marketFixtureForTeam(adapterReturning([ft]), team, during);
+    expect(r.match?.id).not.toBe(opener.id);
+    expect(r.match).toBeDefined(); // the team's next fixture
+  });
+
+  it('keeps the static candidate on a degraded fetch (fail closed downstream)', async () => {
+    const during = new Date(Date.parse(opener.kickoff) + 30 * 60_000);
+    const r = await marketFixtureForTeam(adapterReturning('throw'), team, during);
+    expect(r.match?.id).toBe(opener.id);
+    expect(r.degraded).toBe(true);
+  });
+
+  it('is simply the next fixture outside any window', async () => {
+    const before = new Date(Date.parse(opener.kickoff) - 24 * 60 * 60_000);
+    const r = await marketFixtureForTeam(adapterReturning([]), team, before);
+    expect(r.match?.id).toBe(opener.id);
   });
 });

--- a/packages/core/test/matchday.test.ts
+++ b/packages/core/test/matchday.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import {
+  currentOrNextFixtureForTeam,
+  fixturesInLiveWindow,
+  getMatchById,
+  LIVE_WINDOW_MS,
+  marketRelevant,
+  type Match,
+  type ProviderAdapter,
+} from '../src/index';
+
+function fx(id: string, kickoff: string, over: Partial<Match> = {}): Match {
+  return {
+    id,
+    stage: 'GROUP',
+    group: 'D',
+    kickoff,
+    venue: 'X',
+    home: { code: 'USA', name: 'United States', flag: '🇺🇸' },
+    away: { code: 'PAR', name: 'Paraguay', flag: '🇵🇾' },
+    status: 'SCHEDULED',
+    updatedAt: '2026-06-01T00:00Z',
+    ...over,
+  };
+}
+
+const a = fx('a', '2026-06-12T01:00Z');
+const b = fx('b', '2026-06-19T19:00Z');
+const fixtures = [b, a]; // out of order on purpose — helpers must sort
+
+describe('currentOrNextFixtureForTeam', () => {
+  it('returns the next fixture before kickoff', () => {
+    const got = currentOrNextFixtureForTeam('USA', {
+      from: new Date('2026-06-11T00:00:00Z'),
+      fixtures,
+    });
+    expect(got?.id).toBe('a');
+  });
+
+  it('returns the IN-PLAY fixture during its live window (next would skip it)', () => {
+    const during = new Date(Date.parse(a.kickoff) + 30 * 60_000);
+    expect(currentOrNextFixtureForTeam('usa', { from: during, fixtures })?.id).toBe('a');
+  });
+
+  it('moves on to the next fixture once the window has passed', () => {
+    const after = new Date(Date.parse(a.kickoff) + LIVE_WINDOW_MS + 60_000);
+    expect(currentOrNextFixtureForTeam('USA', { from: after, fixtures })?.id).toBe('b');
+  });
+});
+
+describe('fixturesInLiveWindow', () => {
+  it('contains exactly the fixture whose window covers now', () => {
+    const during = Date.parse(a.kickoff) + 60_000;
+    expect(fixturesInLiveWindow(during, fixtures).map((m) => m.id)).toEqual(['a']);
+    expect(fixturesInLiveWindow(Date.parse('2026-06-01T00:00:00Z'), fixtures)).toEqual([]);
+  });
+});
+
+describe('marketRelevant', () => {
+  it('is true before kickoff and during the live window', () => {
+    expect(marketRelevant(a, new Date('2026-06-11T00:00:00Z'))).toBe(true);
+    expect(marketRelevant(a, new Date(Date.parse(a.kickoff) + 60 * 60_000))).toBe(true);
+  });
+
+  it('is false for FT status and for long-past windows (static fixtures)', () => {
+    expect(marketRelevant(fx('ft', a.kickoff, { status: 'FT' }), new Date(a.kickoff))).toBe(false);
+    expect(marketRelevant(a, new Date(Date.parse(a.kickoff) + LIVE_WINDOW_MS + 60_000))).toBe(
+      false,
+    );
+  });
+
+  it('fails open on an unparseable kickoff (the reliability gate still applies)', () => {
+    expect(marketRelevant(fx('bad', 'not-a-date'), new Date())).toBe(true);
+  });
+});
+
+describe('getMatchById', () => {
+  // The bundled schedule's first fixture; its UTC date may differ from the
+  // provider's scoreboard day — getMatchById must fetch a ±1-day window.
+  it('fetches a ±1-day window and overlays the live match', async () => {
+    const windows: Array<[string, string]> = [];
+    const adapter: ProviderAdapter = {
+      name: 'fake',
+      capabilities: { push: false, latencyHintSec: 0 },
+      async fetchByDate() {
+        throw new Error('should use fetchWindow when available');
+      },
+      async fetchWindow(start: string, end: string) {
+        windows.push([start, end]);
+        const { allFixtures } = await import('../src/index');
+        const base = allFixtures()[0]!;
+        return [{ ...base, status: 'FT' as const, score: { home: 2, away: 0 } }];
+      },
+      async fetchLive() {
+        return [];
+      },
+    };
+    const { allFixtures } = await import('../src/index');
+    const id = allFixtures()[0]!.id;
+    const day = allFixtures()[0]!.kickoff.slice(0, 10);
+    const r = await getMatchById(adapter, id);
+    expect(r.match?.status).toBe('FT');
+    expect(r.source).toBe('fake');
+    expect(windows.length).toBe(1);
+    expect(windows[0]![0] < day && windows[0]![1] > day).toBe(true);
+  });
+
+  it('falls back to the static fixture on provider errors (degraded)', async () => {
+    const adapter: ProviderAdapter = {
+      name: 'boom',
+      capabilities: { push: false, latencyHintSec: 0 },
+      async fetchByDate() {
+        throw new Error('down');
+      },
+      async fetchWindow() {
+        throw new Error('down');
+      },
+      async fetchLive() {
+        return [];
+      },
+    };
+    const { allFixtures } = await import('../src/index');
+    const id = allFixtures()[0]!.id;
+    const r = await getMatchById(adapter, id);
+    expect(r.match?.id).toBe(id);
+    expect(r.degraded).toBe(true);
+    expect(r.source).toBeUndefined();
+  });
+
+  it('returns no match for an unknown id without touching the provider', async () => {
+    let called = false;
+    const adapter: ProviderAdapter = {
+      name: 'fake',
+      capabilities: { push: false, latencyHintSec: 0 },
+      async fetchByDate() {
+        called = true;
+        return [];
+      },
+      async fetchWindow() {
+        called = true;
+        return [];
+      },
+      async fetchLive() {
+        return [];
+      },
+    };
+    const r = await getMatchById(adapter, 'nope');
+    expect(r.match).toBeUndefined();
+    expect(called).toBe(false);
+  });
+});

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -37,7 +37,7 @@ Developer → Edit Config, then restart. Codex config file: `~/.codex/config.tom
 | `get_match` | a single match by id |
 | `get_standings` | group table(s) — one group `A`–`L`, or all |
 | `get_next_fixture` | a team's next match (3-letter code, e.g. `MEX`) — fully offline |
-| `get_market_signal` | read-only prediction-market signal for a match, a team's next fixture, or a date — informational only |
+| `get_market_signal` | read-only prediction-market signal for a match, a team's current-or-next fixture (in-play preferred while live), or a date — informational only |
 | `get_share_snippet` | a copy-pasteable plain-text match card — hand the returned snippet to the user as-is |
 
 All tools are **read-only** (`readOnlyHint`) and accept optional `tz`, `lang`
@@ -50,6 +50,7 @@ the prediction-market read).
 
 ## Market signals
 
+Market signals are pre-match and in-play reads — finished matches never show one.
 `get_today` / `get_match` include a short market line when a reliable market exists
 (slugs are auto-derived per fixture; matching fails closed). **Read-only and
 informational only — not betting advice:** market-implied percentages with Polymarket

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -268,7 +268,7 @@ export function buildServer(): McpServer {
           role: 'user',
           content: {
             type: 'text',
-            text: `Using get_next_fixture, get_standings, and get_market_signal, tell me about ${team}'s next match in the 2026 tournament, their current group standing, and what prediction markets currently say about that match. Treat the market percentages as informational context only — relay them factually, never as betting or trading advice.`,
+            text: `Using get_next_fixture, get_standings, and get_market_signal, tell me about ${team}'s next match in the 2026 tournament, their current group standing, and what prediction markets currently say about that match. Always state each fixture's date so a market read is never mistaken for a different match. Treat the market percentages as informational context only — relay them factually, never as betting or trading advice.`,
           },
         },
       ],

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -39,7 +39,7 @@ const VOICE =
 
 const INSTRUCTIONS = `Claudinho serves live scores, fixtures, and group standings for the 2026 men's football tournament.
 Use get_live during matches, get_today for a day's schedule, get_next_fixture for a specific team (3-letter code, e.g. MEX), and get_standings for group tables.
-Use get_market_signal for read-only prediction-market odds (a match, a team's next fixture, or a date). Market data is informational only — relay the percentages factually and never frame it as betting or trading advice.
+Use get_market_signal for read-only prediction-market signals (a match, a team's current-or-next fixture, or a date). Market data is informational only — relay the percentages factually and never frame it as betting or trading advice.
 Use get_share_snippet to produce a ready-to-paste match card (for a match, a team's next fixture, a date, or live matches) — hand the user the returned snippet text verbatim.${VOICE}
 ${DISCLAIMER}`;
 
@@ -135,7 +135,8 @@ export function buildServer(): McpServer {
     'get_next_fixture',
     {
       title: 'Next fixture for a team',
-      description: "A team's next scheduled match. Use a 3-letter code, e.g. MEX, BRA, USA.",
+      description:
+        "A team's next scheduled match. Use a 3-letter code, e.g. MEX, BRA, USA. Instant and offline — answered from the bundled schedule, no network.",
       inputSchema: { team: teamArg.describe('3-letter team code, e.g. MEX'), ...commonArgs },
       // Read-only and served entirely from the bundled static schedule.
       annotations: { readOnlyHint: true, openWorldHint: false },
@@ -148,12 +149,14 @@ export function buildServer(): McpServer {
     {
       title: 'Prediction-market signal',
       description:
-        "Read-only prediction-market odds for a match (by id), a team's next fixture, or a date (default: today). Returns market-implied percentages with attribution. Informational only — relay the numbers factually; do not add betting, trading, or 'value' advice, and do not invent links.",
+        "Read-only prediction-market signals for a match (by id), a team's current-or-next fixture, or a date (default: today). Returns market-implied percentages with attribution. Shown only before and during a match — finished matches have no market read. Informational only — relay the numbers factually; do not add betting, trading, or 'value' advice, and do not invent links.",
       inputSchema: {
         matchId: z.string().optional().describe('Match id (most specific)'),
         team: teamArg
           .optional()
-          .describe("3-letter team code for that team's next fixture, e.g. MEX"),
+          .describe(
+            "3-letter team code, e.g. MEX — resolves to the team's in-play match when one is live, else their next fixture",
+          ),
         date: dateArg
           .optional()
           .describe("Date as YYYY-MM-DD (default: today) for all that day's signals"),

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -5,10 +5,8 @@
  * payload embedded as JSON for agents that want to parse it.
  */
 import {
-  allFixtures,
   asFlavorLevel,
   computeStandings,
-  currentOrNextFixtureForTeam,
   fixturesByDate,
   fixturesByGroup,
   formatDate,
@@ -27,6 +25,7 @@ import {
   makeAdapter,
   makeMarketProvider,
   marketBlock,
+  marketFixtureForTeam,
   marketRelevant,
   type Match,
   type MarketProvider,
@@ -372,11 +371,9 @@ export async function toolGetMarketSignal(
   // passed and silently answer about a future fixture's (often gated) market.
   if (args.team) {
     const code = args.team.toUpperCase();
-    const base = currentOrNextFixtureForTeam(code, { from: now });
-    // Live overlay: an early FT ends relevance; extra time extends it.
-    const fixture = base
-      ? ((await getMatchById(resolveAdapter(args), base.id)).match ?? base)
-      : undefined;
+    // Live-confirmed selection: handles extra time past the static window AND
+    // early FTs inside it (the static fixture's status is forever SCHEDULED).
+    const { match: fixture } = await marketFixtureForTeam(resolveAdapter(args), code, now);
     const relevant = fixture ? marketRelevant(fixture, now) : false;
     const sig = fixture && relevant ? await getMarketSignal(provider, fixture) : undefined;
     const shown = fixture && sig && marketDisplayable(sig) ? sig : undefined;

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -8,6 +8,7 @@ import {
   allFixtures,
   asFlavorLevel,
   computeStandings,
+  currentOrNextFixtureForTeam,
   fixturesByDate,
   fixturesByGroup,
   formatDate,
@@ -15,6 +16,7 @@ import {
   getLiveMatches,
   getMarketSignal,
   getMarketSignals,
+  getMatchById,
   getMatchesForDate,
   groups,
   hasSaneDistribution,
@@ -24,6 +26,7 @@ import {
   makeAdapter,
   makeMarketProvider,
   marketBlock,
+  marketRelevant,
   type Match,
   type MarketProvider,
   type MarketSignal,
@@ -51,6 +54,8 @@ export interface CommonOpts {
   adapter?: ProviderAdapter;
   /** Injected market provider (tests). Defaults to makeMarketProvider(). */
   marketProvider?: MarketProvider;
+  /** Injected clock (tests) for time-dependent gates (live windows, relevance). */
+  now?: Date;
 }
 
 function resolveAdapter(args: CommonOpts): ProviderAdapter {
@@ -66,12 +71,25 @@ function marketDisplayable(sig: MarketSignal): boolean {
   return !sig.ambiguous && sig.favorite != null && hasSaneDistribution(sig.outcomes);
 }
 
-function marketHeader(m: Match): string {
-  return `${m.home.flag} ${m.home.name} vs ${m.away.name} ${m.away.flag}`;
+/**
+ * Header for a market read, dated. The date is agent UX: "South Korea (Jun 18)"
+ * is the one token that stops a model conflating a future fixture's read (or
+ * its null) with the match being played right now — they skim like we do.
+ */
+function marketHeader(m: Match, args: CommonOpts): string {
+  const when = formatDate(m.kickoff, { tz: args.tz, locale: args.lang });
+  return `${m.home.flag} ${m.home.name} vs ${m.away.name} ${m.away.flag} (${when})`;
 }
 
-function marketText(m: Match, sig: MarketSignal): string {
-  return `${marketHeader(m)}\n${marketBlock(sig, m).join('\n')}`;
+function marketText(m: Match, sig: MarketSignal, args: CommonOpts): string {
+  return `${marketHeader(m, args)}\n${marketBlock(sig, m).join('\n')}`;
+}
+
+/** Null/suppressed-signal text, specific about WHY when the match is finished. */
+function noSignalText(m: Match, args: CommonOpts, now: Date): string {
+  return marketRelevant(m, now)
+    ? `No reliable market signal for ${marketHeader(m, args)}.`
+    : `${marketHeader(m, args)} has finished — market signals are pre-match and in-play reads.`;
 }
 
 /** Structured, link-free market payload. `url` is always null in v1. */
@@ -162,10 +180,14 @@ async function reliableMarketData(
   matches: Match[],
 ): Promise<Record<string, ReturnType<typeof marketData>> | undefined> {
   if (!marketsEnabled()) return undefined;
-  const signals = await cachedMarketSignals(args, matches);
-  const now = new Date();
+  const now = args.now ?? new Date();
+  // Market reads are pre-match/in-play artifacts — never fetch/show for
+  // finished matches (a resolved "favorite" reads as a bug, not information).
+  const relevant = matches.filter((m) => marketRelevant(m, now));
+  if (relevant.length === 0) return undefined;
+  const signals = await cachedMarketSignals(args, relevant);
   const out: Record<string, ReturnType<typeof marketData>> = {};
-  for (const m of matches) {
+  for (const m of relevant) {
     const s = signals.get(m.id);
     if (s && isReliableMarketSignal(s, { now })) out[m.id] = marketData(s);
   }
@@ -227,27 +249,19 @@ export async function toolGetLive(args: CommonOpts = {}): Promise<ToolResult> {
 export async function toolGetMatch(
   args: { id: string } & CommonOpts,
 ): Promise<ToolResult> {
-  let match = allFixtures().find((m) => m.id === args.id);
-  let degraded = false;
-  let liveSource: string | undefined;
-  if (match) {
-    try {
-      const adapter = resolveAdapter(args);
-      const live = await adapter.fetchByDate(match.kickoff.slice(0, 10));
-      match = live.find((m) => m.id === args.id) ?? match;
-      liveSource = adapter.name;
-    } catch {
-      degraded = true;
-    }
-  }
+  // ±1-day window fetch: the provider buckets scoreboard days in its own zone
+  // (ESPN: US/Eastern), so fetching only the fixture's UTC date can miss its
+  // live/final state and silently render the match as still scheduled.
+  const { match, degraded, source: liveSource } = await getMatchById(resolveAdapter(args), args.id);
   if (!match) {
     return { text: withDisclaimer(`No match found with id ${args.id}.`), data: { match: null } };
   }
   const opts = fmtOpts(args);
+  const now = args.now ?? new Date();
   let marketSignal: MarketSignal | undefined;
-  if (marketsEnabled()) {
+  if (marketsEnabled() && marketRelevant(match, now)) {
     const s = (await cachedMarketSignals(args, [match])).get(match.id);
-    if (s && isReliableMarketSignal(s, { now: new Date() })) marketSignal = s;
+    if (s && isReliableMarketSignal(s, { now })) marketSignal = s;
   }
   const base = matchLine(match, opts);
   const text = marketSignal ? `${base}\n${marketBlock(marketSignal, match).join('\n')}` : base;
@@ -326,17 +340,19 @@ export async function toolGetMarketSignal(
   args: { matchId?: string; team?: string; date?: string } & CommonOpts,
 ): Promise<ToolResult> {
   const provider = resolveMarketProvider(args);
+  const now = args.now ?? new Date();
 
   // Most specific: a single match by id.
   if (args.matchId) {
     const match = allFixtures().find((m) => m.id === args.matchId);
-    const sig = match ? await getMarketSignal(provider, match) : undefined;
+    const relevant = match ? marketRelevant(match, now) : false;
+    const sig = match && relevant ? await getMarketSignal(provider, match) : undefined;
     const shown = match && sig && marketDisplayable(sig) ? sig : undefined;
     const text = !match
       ? `No match found with id ${args.matchId}.`
       : shown
-        ? marketText(match, shown)
-        : `No reliable market signal for ${marketHeader(match)}.`;
+        ? marketText(match, shown, args)
+        : noSignalText(match, args, now);
     return {
       text: withDisclaimer(text),
       data: {
@@ -347,17 +363,20 @@ export async function toolGetMarketSignal(
     };
   }
 
-  // A team's next fixture.
+  // A team's current-or-next fixture. Mid-match, a team query means the match
+  // being played — `nextFixtureForTeam` alone would skip it the moment kickoff
+  // passed and silently answer about a future fixture's (often gated) market.
   if (args.team) {
     const code = args.team.toUpperCase();
-    const fixture = nextFixtureForTeam(code);
-    const sig = fixture ? await getMarketSignal(provider, fixture) : undefined;
+    const fixture = currentOrNextFixtureForTeam(code, { from: now });
+    const relevant = fixture ? marketRelevant(fixture, now) : false;
+    const sig = fixture && relevant ? await getMarketSignal(provider, fixture) : undefined;
     const shown = fixture && sig && marketDisplayable(sig) ? sig : undefined;
     const text = !fixture
       ? `No upcoming fixture found for ${code}.`
       : shown
-        ? marketText(fixture, shown)
-        : `No reliable market signal for ${code}'s next fixture.`;
+        ? marketText(fixture, shown, args)
+        : noSignalText(fixture, args, now);
     return {
       text: withDisclaimer(text),
       data: {
@@ -370,9 +389,9 @@ export async function toolGetMarketSignal(
   }
 
   // A date's matches (default: today).
-  const date = args.date ?? localDate(new Date().toISOString(), args.tz);
+  const date = args.date ?? localDate(now.toISOString(), args.tz);
   const { matches } = await getMatchesForDate(resolveAdapter(args), date);
-  const todays = fixturesByDate(date, matches, args.tz);
+  const todays = fixturesByDate(date, matches, args.tz).filter((m) => marketRelevant(m, now));
   const { signals } = await getMarketSignals(provider, todays, MARKETS_TOOL_OPTS);
   const shown = todays
     .map((m) => ({ match: m, signal: signals.get(m.id) }))
@@ -382,7 +401,7 @@ export async function toolGetMarketSignal(
     );
   const text = shown.length
     ? `Market signals on ${date}:\n${shown
-        .map(({ match, signal }) => marketText(match, signal))
+        .map(({ match, signal }) => marketText(match, signal, args))
         .join('\n\n')}`
     : `No reliable market signals on ${date}.`;
   return {
@@ -401,10 +420,12 @@ async function reliableSignalMap(
   matches: Match[],
 ): Promise<Map<string, MarketSignal>> {
   if (!marketsEnabled()) return new Map();
-  const signals = await cachedMarketSignals(args, matches);
-  const now = new Date();
+  const now = args.now ?? new Date();
+  const relevant = matches.filter((m) => marketRelevant(m, now));
+  if (relevant.length === 0) return new Map();
+  const signals = await cachedMarketSignals(args, relevant);
   const out = new Map<string, MarketSignal>();
-  for (const m of matches) {
+  for (const m of relevant) {
     const s = signals.get(m.id);
     if (s && isReliableMarketSignal(s, { now }) && marketDisplayable(s)) out.set(m.id, s);
   }
@@ -499,20 +520,9 @@ export async function toolGetShareSnippet(args: ShareArgs): Promise<ToolResult> 
     );
   }
 
-  // a single match by id, with live overlay for that day.
+  // a single match by id, with live overlay (±1-day window — see toolGetMatch).
   if (args.matchId) {
-    let match = allFixtures().find((m) => m.id === args.matchId);
-    let source: string | undefined;
-    if (match) {
-      try {
-        const adapter = resolveAdapter(args);
-        const live = await adapter.fetchByDate(match.kickoff.slice(0, 10));
-        match = live.find((m) => m.id === args.matchId) ?? match;
-        source = adapter.name;
-      } catch {
-        /* keep static */
-      }
-    }
+    const { match, source } = await getMatchById(resolveAdapter(args), args.matchId);
     const matches = match ? [match] : [];
     return shareResult(
       'match',

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -21,6 +21,7 @@ import {
   groups,
   hasSaneDistribution,
   isReliableMarketSignal,
+  isFinished,
   liveSourceLabel,
   localDate,
   makeAdapter,
@@ -87,9 +88,11 @@ function marketText(m: Match, sig: MarketSignal, args: CommonOpts): string {
 
 /** Null/suppressed-signal text, specific about WHY when the match is finished. */
 function noSignalText(m: Match, args: CommonOpts, now: Date): string {
-  return marketRelevant(m, now)
-    ? `No reliable market signal for ${marketHeader(m, args)}.`
-    : `${marketHeader(m, args)} has finished — market signals are pre-match and in-play reads.`;
+  if (marketRelevant(m, now)) return `No reliable market signal for ${marketHeader(m, args)}.`;
+  // "has finished" only when a live overlay confirmed it; a static fixture
+  // whose window merely lapsed gets the honest, hedged variant.
+  const verb = isFinished(m.status) ? 'has finished' : 'appears to have finished';
+  return `${marketHeader(m, args)} ${verb} — market signals are pre-match and in-play reads.`;
 }
 
 /** Structured, link-free market payload. `url` is always null in v1. */
@@ -332,7 +335,7 @@ export async function toolGetNextFixture(
 }
 
 /**
- * market_signal: read-only prediction-market odds for a single match (by id), a
+ * market_signal: read-only prediction-market signals for a single match (by id), a
  * team's next fixture, or all of a date's matches (default: today). Returns
  * market-implied percentages with attribution; never links, never advice.
  */
@@ -342,9 +345,10 @@ export async function toolGetMarketSignal(
   const provider = resolveMarketProvider(args);
   const now = args.now ?? new Date();
 
-  // Most specific: a single match by id.
+  // Most specific: a single match by id — with live overlay so FT gates the
+  // resolved market correctly (the static fixture's status never changes).
   if (args.matchId) {
-    const match = allFixtures().find((m) => m.id === args.matchId);
+    const { match } = await getMatchById(resolveAdapter(args), args.matchId);
     const relevant = match ? marketRelevant(match, now) : false;
     const sig = match && relevant ? await getMarketSignal(provider, match) : undefined;
     const shown = match && sig && marketDisplayable(sig) ? sig : undefined;
@@ -368,7 +372,11 @@ export async function toolGetMarketSignal(
   // passed and silently answer about a future fixture's (often gated) market.
   if (args.team) {
     const code = args.team.toUpperCase();
-    const fixture = currentOrNextFixtureForTeam(code, { from: now });
+    const base = currentOrNextFixtureForTeam(code, { from: now });
+    // Live overlay: an early FT ends relevance; extra time extends it.
+    const fixture = base
+      ? ((await getMatchById(resolveAdapter(args), base.id)).match ?? base)
+      : undefined;
     const relevant = fixture ? marketRelevant(fixture, now) : false;
     const sig = fixture && relevant ? await getMarketSignal(provider, fixture) : undefined;
     const shown = fixture && sig && marketDisplayable(sig) ? sig : undefined;

--- a/packages/mcp/test/market.test.ts
+++ b/packages/mcp/test/market.test.ts
@@ -42,7 +42,12 @@ type MarketData = {
 describe('toolGetMarketSignal', () => {
   it('returns a link-free, informational signal for a match id', async () => {
     const id = upcoming().id;
-    const r = await toolGetMarketSignal({ matchId: id, marketProvider: synth(), now: TEST_NOW });
+    const r = await toolGetMarketSignal({
+      matchId: id,
+      adapter: fakeAdapter,
+      marketProvider: synth(),
+      now: TEST_NOW,
+    });
     const data = r.data as { matchId: string; signal: MarketData | null };
     expect(data.matchId).toBe(id);
     expect(data.signal).not.toBeNull();
@@ -54,14 +59,14 @@ describe('toolGetMarketSignal', () => {
   });
 
   it('returns a null signal for an unknown match id', async () => {
-    const r = await toolGetMarketSignal({ matchId: 'nope', marketProvider: synth() });
+    const r = await toolGetMarketSignal({ matchId: 'nope', adapter: fakeAdapter, marketProvider: synth() });
     expect((r.data as { signal: null }).signal).toBeNull();
     expect(r.text).toContain('No match found');
   });
 
   it("resolves a team's current-or-next fixture", async () => {
     const team = upcoming().home.code;
-    const r = await toolGetMarketSignal({ team, marketProvider: synth(), now: TEST_NOW });
+    const r = await toolGetMarketSignal({ team, adapter: fakeAdapter, marketProvider: synth(), now: TEST_NOW });
     const data = r.data as { team: string; informationalOnly: boolean };
     expect(data.team).toBe(team);
     expect(data.informationalOnly).toBe(true);
@@ -74,6 +79,7 @@ describe('toolGetMarketSignal', () => {
     const during = new Date(Date.parse(opener.kickoff) + 30 * 60_000);
     const r = await toolGetMarketSignal({
       team: opener.home.code,
+      adapter: fakeAdapter,
       marketProvider: synth(),
       now: during,
     });
@@ -85,6 +91,7 @@ describe('toolGetMarketSignal', () => {
     const after = new Date(Date.parse(opener.kickoff) + 6 * 60 * 60_000);
     const r = await toolGetMarketSignal({
       matchId: opener.id,
+      adapter: fakeAdapter,
       marketProvider: synth(),
       now: after,
     });
@@ -95,6 +102,7 @@ describe('toolGetMarketSignal', () => {
   it('dates the fixture in the null-signal text (agents skim)', async () => {
     const r = await toolGetMarketSignal({
       matchId: upcoming().id,
+      adapter: fakeAdapter,
       marketProvider: new FakeMarketProvider(), // synthesize off → no signal
       now: TEST_NOW,
     });

--- a/packages/mcp/test/market.test.ts
+++ b/packages/mcp/test/market.test.ts
@@ -20,8 +20,18 @@ const fakeAdapter: ProviderAdapter = {
   },
 };
 
-const synth = () =>
-  new FakeMarketProvider({ synthesize: true, now: new Date('2026-06-13T12:00:00Z') });
+/**
+ * Fixed clock for time-dependent gates (relevance, live windows, freshness) —
+ * deterministic forever, including after the tournament when every fixture's
+ * window is in the real past.
+ */
+const TEST_NOW = new Date('2026-06-13T12:00:00Z');
+
+const synth = () => new FakeMarketProvider({ synthesize: true, now: TEST_NOW });
+
+/** A fixture still upcoming at TEST_NOW (its market read is relevant). */
+const upcoming = (): Match =>
+  allFixtures().find((m) => Date.parse(m.kickoff) > TEST_NOW.getTime())!;
 
 type MarketData = {
   market: { url: null };
@@ -31,8 +41,8 @@ type MarketData = {
 
 describe('toolGetMarketSignal', () => {
   it('returns a link-free, informational signal for a match id', async () => {
-    const id = allFixtures()[0]!.id;
-    const r = await toolGetMarketSignal({ matchId: id, marketProvider: synth() });
+    const id = upcoming().id;
+    const r = await toolGetMarketSignal({ matchId: id, marketProvider: synth(), now: TEST_NOW });
     const data = r.data as { matchId: string; signal: MarketData | null };
     expect(data.matchId).toBe(id);
     expect(data.signal).not.toBeNull();
@@ -49,12 +59,47 @@ describe('toolGetMarketSignal', () => {
     expect(r.text).toContain('No match found');
   });
 
-  it("resolves a team's next fixture", async () => {
-    const team = allFixtures()[0]!.home.code;
-    const r = await toolGetMarketSignal({ team, marketProvider: synth() });
+  it("resolves a team's current-or-next fixture", async () => {
+    const team = upcoming().home.code;
+    const r = await toolGetMarketSignal({ team, marketProvider: synth(), now: TEST_NOW });
     const data = r.data as { team: string; informationalOnly: boolean };
     expect(data.team).toBe(team);
     expect(data.informationalOnly).toBe(true);
+  });
+
+  it("prefers the team's IN-PLAY match over their next fixture", async () => {
+    // Mid-opener clock: the first fixture is being played right now. A plain
+    // "next fixture" lookup would skip it and answer about a future match.
+    const opener = allFixtures()[0]!;
+    const during = new Date(Date.parse(opener.kickoff) + 30 * 60_000);
+    const r = await toolGetMarketSignal({
+      team: opener.home.code,
+      marketProvider: synth(),
+      now: during,
+    });
+    expect((r.data as { matchId: string }).matchId).toBe(opener.id);
+  });
+
+  it('suppresses the signal for a finished match (market reads are pre-match)', async () => {
+    const opener = allFixtures()[0]!;
+    const after = new Date(Date.parse(opener.kickoff) + 6 * 60 * 60_000);
+    const r = await toolGetMarketSignal({
+      matchId: opener.id,
+      marketProvider: synth(),
+      now: after,
+    });
+    expect((r.data as { signal: unknown }).signal).toBeNull();
+    expect(r.text).toContain('market signals are pre-match and in-play reads');
+  });
+
+  it('dates the fixture in the null-signal text (agents skim)', async () => {
+    const r = await toolGetMarketSignal({
+      matchId: upcoming().id,
+      marketProvider: new FakeMarketProvider(), // synthesize off → no signal
+      now: TEST_NOW,
+    });
+    expect(r.text).toContain('No reliable market signal for');
+    expect(r.text).toMatch(/\(.+\)/); // the "(Jun 18)"-style date disambiguator
   });
 
   it('lists a date of signals (default branch)', async () => {
@@ -63,6 +108,7 @@ describe('toolGetMarketSignal', () => {
       tz: 'UTC',
       adapter: fakeAdapter,
       marketProvider: synth(),
+      now: TEST_NOW,
     });
     const data = r.data as { date: string; signals: MarketData[] };
     expect(data.date).toBe('2026-06-13');
@@ -85,6 +131,7 @@ describe('toolGetMarketSignal', () => {
       tz: 'UTC',
       adapter: fakeAdapter,
       marketProvider: boom,
+      now: TEST_NOW,
     });
     expect((r.data as { signals: unknown[] }).signals).toEqual([]);
   });
@@ -97,6 +144,7 @@ describe('default-on market context', () => {
       tz: 'UTC',
       adapter: fakeAdapter,
       marketProvider: synth(),
+      now: TEST_NOW,
     });
     const data = r.data as { marketSignals?: Record<string, MarketData> };
     expect(data.marketSignals).toBeDefined();
@@ -104,8 +152,8 @@ describe('default-on market context', () => {
   });
 
   it('get_match appends a reliable market block', async () => {
-    const id = allFixtures()[0]!.id;
-    const r = await toolGetMatch({ id, adapter: fakeAdapter, marketProvider: synth() });
+    const id = upcoming().id;
+    const r = await toolGetMatch({ id, adapter: fakeAdapter, marketProvider: synth(), now: TEST_NOW });
     const data = r.data as { marketSignal: MarketData | null };
     expect(data.marketSignal).not.toBeNull();
     expect(r.text).toContain('Prediction markets');


### PR DESCRIPTION
Five field-tested fixes from launch day, plus the planned copy sweep — hardened by an independent adversarial review pass (no P1s; all P2s applied).

## What the opener taught us

| # | Fix | Field incident |
|---|---|---|
| 1 | Statusline cold/stale cache during a live window renders **`⚽ 🇽🇽 vs 🇾🇾 live · syncing…`** (from the static schedule) instead of a next-match countdown; degraded snapshots are not trusted | Statusline showed a countdown while MEX–RSA was in play |
| 2 | Market **team queries prefer the in-play match**; market blocks **suppressed for finished matches** (LIVE overlay outranks the time window in both directions — extra time stays relevant, early FT ends it); null texts/headers carry the **fixture date** | "market signals for Mexico" silently answered about Jun 18's gated market; the FT card printed "Mexico 100%" |
| 3 | Match-by-id fetches use a **±1-day window** (new core `getMatchById`) — ESPN buckets scoreboard days in US/Eastern | `match 760414` showed SCHEDULED after full time |
| 4 | **Config-drift guard**: stderr warning when `CLAUDINHO_COMPETITION` diverges from the bundled schedule (never on the hot path, never in `--json` stdout) | A leftover `fifa.friendly` env blanked the statusline during the opener |
| 5 | `CLAUDINHO_TEAM` as default team for `next` / `markets next` / `share next`; matchday-aware `vibe`; **"odds" → "signals"** copy sweep (MCP instructions + tool descriptions matter most — agents echo them) | — |

## Discipline
- Hot path untouched by anything async/network: the new syncing render is a pure static-schedule scan; `precheck` (and its warning) never runs for `prompt`/`hook`.
- No `--json` shape breaks (one additive key: `match --json` gains `degraded`).
- Market-surface changes went through the independent adversarial reviewer per AGENTS.md; findings and fixes are in the second commit's message.
- Market test suites now pin an explicit clock — deterministic after the tournament ends too. 294 tests green, lint/typecheck/build green.

## Release notes
Versions stay at 0.4.2 in this PR; the 0.4.3 bump + tag follows the merge per the release checklist. `CLAUDINHO_COMPETITION` remains deliberately undocumented in READMEs per the launch trim (BACKLOG re-docs it post-tournament) — the new warning is self-explanatory when it fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)