### PR TITLE
Stop mid-tournament test rot: thread the clock through next-fixture resolution

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -272,10 +272,10 @@ export async function cmdLive(ctx: Ctx): Promise<void> {
 }
 
 /** `claudinho next [team]` (team defaults to CLAUDINHO_TEAM) */
-export async function cmdNext(team: string | undefined, { cfg, t }: Ctx): Promise<void> {
+export async function cmdNext(team: string | undefined, { cfg, t, now }: Ctx): Promise<void> {
   precheck(cfg, t);
   const code = resolveTeamArg(team, 'Usage: claudinho next <team> (or set CLAUDINHO_TEAM)');
-  const fixture = nextFixtureForTeam(code);
+  const fixture = nextFixtureForTeam(code, { from: now ?? new Date() });
 
   if (cfg.json) {
     emitJson({ team: code, fixture: fixture ?? null });
@@ -793,7 +793,7 @@ export async function cmdShare(
   if (target === 'next') {
     precheck(cfg, t);
     const code = resolveTeamArg(team, 'Usage: claudinho share next <team> (or set CLAUDINHO_TEAM)');
-    const fixture = nextFixtureForTeam(code);
+    const fixture = nextFixtureForTeam(code, { from: ctx.now ?? new Date() });
     const matches = fixture ? [fixture] : [];
     const signals = await reliableShareSignals(ctx, matches);
     const teamName = fixture

--- a/packages/cli/test/share.test.ts
+++ b/packages/cli/test/share.test.ts
@@ -22,12 +22,17 @@ const fakeAdapter: ProviderAdapter = {
   },
 };
 
+// Fixed in-tournament clock. Pins BOTH the share command's fixture resolution
+// (via ctx.now) AND the synthesized signal's freshness, so the suite stays
+// deterministic after these fixtures fall into the real past.
+const TEST_NOW = new Date('2026-06-13T12:00:00Z');
+
 /** A fresh, cleanly-mapped, reliable signal for a given match. */
 const freshSig = (m: Match): MarketSignal => ({
   matchId: m.id,
   source: 'polymarket',
-  asOf: new Date().toISOString(),
-  fetchedAt: new Date().toISOString(),
+  asOf: TEST_NOW.toISOString(),
+  fetchedAt: TEST_NOW.toISOString(),
   outcomes: [
     { kind: 'home', teamCode: m.home.code, label: m.home.name, probability: 0.56 },
     { kind: 'draw', label: 'Draw', probability: 0.25 },
@@ -64,6 +69,7 @@ const ctx = (over: Over = {}, marketProvider: MarketProvider = provider(), copy?
   adapter: fakeAdapter,
   marketProvider,
   copy,
+  now: TEST_NOW,
 });
 
 const outSpy = vi.spyOn(process.stdout, 'write');

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -319,7 +319,10 @@ export async function toolGetNextFixture(
   args: { team: string } & CommonOpts,
 ): Promise<ToolResult> {
   const code = args.team.toUpperCase();
-  const fixture = nextFixtureForTeam(code);
+  // Thread the caller's clock so "next fixture" is deterministic in tests and
+  // doesn't silently resolve against the real wall-clock (which goes null once a
+  // team's last *known* fixture passes — knockouts are placeholders).
+  const fixture = nextFixtureForTeam(code, { from: args.now ?? new Date() });
   if (!fixture) {
     return {
       text: withDisclaimer(`No upcoming fixture found for ${code}.`),
@@ -550,7 +553,7 @@ export async function toolGetShareSnippet(args: ShareArgs): Promise<ToolResult> 
   // a team's next fixture (static schedule + reliable market read).
   if (args.team) {
     const code = args.team.toUpperCase();
-    const fixture = nextFixtureForTeam(code);
+    const fixture = nextFixtureForTeam(code, { from: args.now ?? new Date() });
     const matches = fixture ? [fixture] : [];
     const teamName = fixture
       ? fixture.home.code === code

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -7,6 +7,11 @@ import {
   toolGetToday,
 } from '../src/tools';
 
+// Fixed in-tournament clock — pin it on calls whose result is "now"-relative
+// (e.g. a team's next fixture), so they don't rot as real time passes a team's
+// last known fixture (knockouts are placeholders, so resolution goes null).
+const TEST_NOW = new Date('2026-06-13T12:00:00Z');
+
 function liveMatch(over: Partial<Match> = {}): Match {
   return {
     id: '760415',
@@ -113,7 +118,7 @@ describe('toolGetToday', () => {
 
 describe('toolGetNextFixture (pure static)', () => {
   it('returns the next fixture for a team code', async () => {
-    const r = await toolGetNextFixture({ team: 'bra' });
+    const r = await toolGetNextFixture({ team: 'bra', now: TEST_NOW });
     const data = r.data as { team: string; fixture: Match | null };
     expect(data.team).toBe('BRA');
     expect(data.fixture).toBeTruthy();


### PR DESCRIPTION
## What
A proactive sweep — running the whole suite under a **faked post-tournament clock** — caught two more time-bombs beyond the one fixed in #13. These rot **during** the tournament (~Jun 25), not just after.

`toolGetNextFixture` (mcp) and the cli `share next` path resolved a team's next fixture against the **real wall-clock**, ignoring the `now`/`ctx.now` they already accept. A team's last *known* fixture is its final group game (knockouts are placeholders), so resolution goes `null` ~5 days in → the market-block + fixture-truthy assertions turn red right in the knockout-content window.

## Fix
Thread the caller's clock into all **four** unthreaded `nextFixtureForTeam()` call sites:
- mcp: `toolGetNextFixture`, share-snippet team path
- cli: `cmdNext`, `share next` path

**Zero production behavior change** — default stays `new Date()`; it just makes resolution clock-injectable, matching every other tool. The two affected tests (and `freshSig`'s timestamps) are pinned to a fixed in-tournament `TEST_NOW`.

## Verification
- Full suite green at **real time** AND under a **2026-07-20 (post-final) clock** — 298/298 both ways → deterministic going forward.
- typecheck + lint clean.

Method: a Node `--import` shim overriding no-arg `new Date()`/`Date.now()` to a future instant; tests that pin their own clock stayed green (proving they're safe), the rotters flipped red, then green after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)