### PR TITLE
Detect in-play matches the provider files under an adjacent day bucket

### DIFF
--- a/packages/cli/src/refresh.ts
+++ b/packages/cli/src/refresh.ts
@@ -8,6 +8,7 @@ import { spawn } from 'node:child_process';
 import {
   DEFAULT_COMPETITION,
   EspnAdapter,
+  getLiveMatches,
   makeAdapter,
   resolveCompetition,
   type Match,
@@ -78,8 +79,16 @@ export async function runRefresh(opts: RefreshOpts = {}): Promise<void> {
     let degraded = false;
 
     if (liveWindowActive(now.getTime())) {
+      // Use the domain helper, not adapter.fetchLive() directly: it fetches a
+      // ±1-day window around `now` so a late kickoff filed under the provider's
+      // adjacent day bucket is still detected (see core getLiveMatches). Without
+      // this the statusline cache reads empty mid-match and shows a countdown.
+      // getLiveMatches fails closed internally; the try also guards adapter
+      // construction so any error degrades rather than skipping the cache write.
       try {
-        live = await liveAdapter().fetchLive();
+        const r = await getLiveMatches(liveAdapter(), now);
+        live = r.matches;
+        degraded = r.degraded;
       } catch {
         degraded = true;
       }

--- a/packages/cli/test/refresh.test.ts
+++ b/packages/cli/test/refresh.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { shouldRefresh } from '../src/refresh';
+import { readState } from '../src/cache';
+import { runRefresh, shouldRefresh } from '../src/refresh';
 
 // A time well outside any World Cup window (tournament starts 2026-06-11).
 const PRE_WC = new Date('2026-06-04T16:00:00Z').getTime();
@@ -32,5 +33,75 @@ describe('shouldRefresh — competition-aware live window', () => {
     // and a stale cache is allowed to refresh.
     process.env.CLAUDINHO_COMPETITION = 'fifa.friendly';
     expect(shouldRefresh(PRE_WC)).toBe(true);
+  });
+});
+
+// ESPN-shaped scoreboard: the in-play match kicked off at 04:00Z (the provider
+// files it under its NEXT day bucket) plus an already-FT match from the default
+// bucket. A no-date fetchLive() would return [] here; the windowed path must
+// keep only the in-play match.
+const SCOREBOARD = {
+  day: { date: '2026-06-16' },
+  events: [
+    {
+      id: '760431',
+      date: '2026-06-17T04:00Z',
+      name: 'Jordan at Austria',
+      season: { year: 2026, slug: 'group-stage' },
+      status: {
+        type: { name: 'STATUS_IN_PROGRESS', state: 'in', completed: false },
+        displayClock: "76'",
+        period: 2,
+      },
+      competitions: [
+        {
+          venue: { fullName: 'Ernst-Happel-Stadion' },
+          competitors: [
+            { homeAway: 'home', score: '2', team: { abbreviation: 'AUT', displayName: 'Austria' } },
+            { homeAway: 'away', score: '1', team: { abbreviation: 'JOR', displayName: 'Jordan' } },
+          ],
+        },
+      ],
+    },
+    {
+      id: '760415',
+      date: '2026-06-16T19:00Z',
+      name: 'Senegal at France',
+      season: { year: 2026, slug: 'group-stage' },
+      status: { type: { name: 'STATUS_FULL_TIME', state: 'post', completed: true } },
+      competitions: [
+        {
+          venue: { fullName: 'MetLife Stadium' },
+          competitors: [
+            { homeAway: 'home', score: '3', team: { abbreviation: 'FRA', displayName: 'France' } },
+            { homeAway: 'away', score: '1', team: { abbreviation: 'SEN', displayName: 'Senegal' } },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe('runRefresh — windowed live detection (statusline regression)', () => {
+  // During the AUT-JOR window. A bare fetchLive() (no-date bucket) returned [],
+  // so the statusline cache read empty mid-match and showed a countdown. The
+  // refresher must now window around `now` and persist the in-play match.
+  const DURING = new Date('2026-06-17T05:00:00Z');
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => SCOREBOARD })),
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('persists the adjacent-bucket live match, not an empty list', async () => {
+    await runRefresh({ now: DURING, source: 'espn' });
+    const state = readState();
+    expect(state?.degraded).toBe(false);
+    // Only the in-play match — the FT one in the default bucket is filtered out.
+    expect((state?.live ?? []).map((m) => m.id)).toEqual(['760431']);
+    expect((state?.live ?? [])[0]?.status).toBe('LIVE');
   });
 });

--- a/packages/core/src/adapters/espn.ts
+++ b/packages/core/src/adapters/espn.ts
@@ -13,6 +13,7 @@ import type { GroupStandings, StandingRow } from '../standings';
 import type { Match, Stage, Status, Team } from '../types';
 import type { ProviderAdapter, ProviderCapabilities } from './types';
 import { nationToFlag } from '../flags';
+import { isLive } from '../normalize';
 
 const ESPN_SOCCER = 'https://site.api.espn.com/apis/site/v2/sports/soccer';
 /** Default competition slug (the 2026 World Cup). */
@@ -300,9 +301,15 @@ export class EspnAdapter implements ProviderAdapter {
     return this.fetchScoreboard(`${toEspnDate(startDate)}-${toEspnDate(endDate)}`);
   }
 
+  /**
+   * In-play matches from ESPN's DEFAULT scoreboard bucket only (no `dates`). This
+   * single bucket misses a late kickoff ESPN files under an adjacent day, so it
+   * is a fallback for window-less callers — the domain `getLiveMatches` wraps a
+   * ±1-day window around this to catch boundary-crossing matches. Prefer it.
+   */
   async fetchLive(): Promise<Match[]> {
     const today = await this.fetchScoreboard();
-    return today.filter((m) => m.status === 'LIVE' || m.status === 'HT');
+    return today.filter((m) => isLive(m.status));
   }
 
   /** Standings endpoint URL (lives under apis/v2, not site/v2; derived from base). */

--- a/packages/core/src/live.ts
+++ b/packages/core/src/live.ts
@@ -5,7 +5,7 @@
  */
 import { competitionBase, DEFAULT_COMPETITION, EspnAdapter } from './adapters/espn';
 import type { ProviderAdapter } from './adapters/types';
-import { isFinished } from './normalize';
+import { isFinished, isLive } from './normalize';
 import {
   allFixtures,
   fixturesByGroup,
@@ -225,10 +225,31 @@ export async function getMatchById(
   }
 }
 
-/** Currently-live matches; empty + degraded on error. */
-export async function getLiveMatches(adapter: ProviderAdapter): Promise<LiveResult> {
+/**
+ * Currently-live matches; empty + degraded on error.
+ *
+ * The provider buckets its scoreboard by its own day (ESPN: US/Eastern), so a
+ * late kickoff that crossed the day boundary lands in an ADJACENT bucket — a
+ * 04:00Z match still live at 76' while the provider's default "today" bucket
+ * already shows the prior, all-FT day. A bare `adapter.fetchLive()` reads only
+ * that single default bucket, so it silently MISSES such a match and `live` /
+ * the statusline / the hook show "nothing live" mid-match. Fetch the ±1-day UTC
+ * window around `now` instead — the same trick {@link getMatchesForDate} and
+ * {@link getMatchById} use — and filter to in-play, so no live match can hide in
+ * an adjacent bucket. Adapters without a window fetch fall back to `fetchLive()`.
+ */
+export async function getLiveMatches(
+  adapter: ProviderAdapter,
+  now: Date = new Date(),
+): Promise<LiveResult> {
   try {
-    return { matches: await adapter.fetchLive(), degraded: false, source: adapter.name };
+    const day = now.toISOString().slice(0, 10);
+    const matches = adapter.fetchWindow
+      ? (await adapter.fetchWindow(shiftUtcDate(day, -1), shiftUtcDate(day, 1))).filter((m) =>
+          isLive(m.status),
+        )
+      : await adapter.fetchLive();
+    return { matches, degraded: false, source: adapter.name };
   } catch {
     return { matches: [], degraded: true };
   }

--- a/packages/core/test/live.test.ts
+++ b/packages/core/test/live.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getMatchesForDate, type Match, type ProviderAdapter } from '../src/index';
+import { getLiveMatches, getMatchesForDate, type Match, type ProviderAdapter } from '../src/index';
 
 function fx(id: string, kickoff: string, over: Partial<Match> = {}): Match {
   return {
@@ -92,5 +92,81 @@ describe('getMatchesForDate — spanning-window overlay (P1)', () => {
     const { matches, degraded } = await getMatchesForDate(adapter, '2026-06-12');
     expect(degraded).toBe(true);
     expect(matches.length).toBeGreaterThan(0); // bundled fixtures still present
+  });
+});
+
+describe('getLiveMatches — windowed in-play detection (P1)', () => {
+  it('finds a live match the provider files under an ADJACENT day bucket', async () => {
+    // Real incident: a 04:00Z kickoff live at 76', while the provider's no-date
+    // "today" bucket already shows the prior, all-FT day → a bare fetchLive()
+    // misses it and the statusline shows a countdown mid-match. The ±1-day
+    // window around `now` must catch it.
+    const liveLate = fx('760431', '2026-06-17T04:00Z', {
+      status: 'LIVE',
+      minute: 76,
+      score: { home: 2, away: 1 },
+    });
+    const ftEarlier = fx('760415', '2026-06-16T19:00Z', { status: 'FT', score: { home: 3, away: 1 } });
+    const upcoming = fx('760432', '2026-06-17T17:00Z', { status: 'SCHEDULED' });
+    const { adapter, calls } = windowAdapter([ftEarlier, liveLate, upcoming]);
+
+    const { matches, degraded, source } = await getLiveMatches(
+      adapter,
+      new Date('2026-06-17T05:46:00Z'),
+    );
+
+    expect(degraded).toBe(false);
+    expect(source).toBe('win');
+    expect(calls).toEqual([['2026-06-16', '2026-06-18']]); // now ±1 day
+    // Only the in-play match — not the FT or the not-yet-started one.
+    expect(matches.map((m) => m.id)).toEqual(['760431']);
+    expect(matches[0]?.status).toBe('LIVE');
+  });
+
+  it('includes HT and excludes FT / SCHEDULED', async () => {
+    const ht = fx('a', '2026-06-17T04:00Z', { status: 'HT', score: { home: 0, away: 0 } });
+    const ft = fx('b', '2026-06-17T01:00Z', { status: 'FT' });
+    const sched = fx('c', '2026-06-17T20:00Z', { status: 'SCHEDULED' });
+    const { adapter } = windowAdapter([ht, ft, sched]);
+    const { matches } = await getLiveMatches(adapter, new Date('2026-06-17T05:00:00Z'));
+    expect(matches.map((m) => m.id)).toEqual(['a']);
+  });
+
+  it('falls back to fetchLive() when the adapter has no fetchWindow', async () => {
+    const live = fx('z', '2026-06-17T04:00Z', { status: 'LIVE' });
+    const calls: string[] = [];
+    const adapter: ProviderAdapter = {
+      name: 'date',
+      capabilities: { push: false, latencyHintSec: 0 },
+      async fetchByDate() {
+        return [];
+      },
+      async fetchLive() {
+        calls.push('live');
+        return [live];
+      },
+    };
+    const { matches } = await getLiveMatches(adapter, new Date('2026-06-17T05:00:00Z'));
+    expect(calls).toEqual(['live']);
+    expect(matches.map((m) => m.id)).toEqual(['z']);
+  });
+
+  it('degrades to empty on a provider error (never a confidently-empty live list)', async () => {
+    const adapter: ProviderAdapter = {
+      name: 'boom',
+      capabilities: { push: false, latencyHintSec: 0 },
+      async fetchByDate() {
+        return [];
+      },
+      async fetchLive() {
+        return [];
+      },
+      async fetchWindow() {
+        throw new Error('down');
+      },
+    };
+    const { matches, degraded } = await getLiveMatches(adapter, new Date('2026-06-17T05:00:00Z'));
+    expect(degraded).toBe(true);
+    expect(matches).toEqual([]);
   });
 });


### PR DESCRIPTION
## The bug (you hit this live)

On your Claude CLI statusline, a match in progress showed as a **countdown to the next fixture** instead of the live score. Reproduced against the real ESPN feed: **Austria 2–1 Jordan was live at 76'**, yet `claudinho live`, the statusline, the hook, and the share/MCP live surfaces all said *"nothing live."*

## Root cause

`adapter.fetchLive()` reads ESPN's **single default scoreboard bucket** (no `dates` param). ESPN buckets the scoreboard by its own day, so a **late kickoff** (here 04:00Z) lands in the **next** day's bucket until ESPN's default bucket rolls forward. For the window right after such a kickoff, the live match is invisible to `fetchLive()`:

- no-date bucket → the prior day, **all FT**
- `dates=<next day>` → the match **`in` at 76'**

It's a **race** between ESPN's bucket rollover and the match being live — which is why minutes later it "fixed itself" (the bucket caught up).

`getMatchById` and `getMatchesForDate` already dodge this exact day-bucketing with a ±1-day window. `getLiveMatches` was the missing third instance.

## The fix

- **`core/getLiveMatches(adapter, now = new Date())`** — fetch the ±1-day UTC window around `now` via `fetchWindow` and filter to in-play (`isLive`), falling back to `fetchLive()` for window-less adapters. Clock-injectable, like `marketFixtureForTeam`.
- **Refresher** (the statusline/hook cache writer) now calls `getLiveMatches` instead of `adapter.fetchLive()` directly, threading its `now` — so the fix reaches the statusline. Keeps the fail-closed try/catch.
- Annotated `adapter.fetchLive()` as the narrow single-bucket fallback.

Every live surface (CLI `live`/`share live`, MCP `get_live`/`share live`, statusline, hook) flows through `getLiveMatches`, so one domain fix covers them all. **No hot-path change** — the statusline still reads cache only; the cold-path refresher makes the same single windowed request (group-enrichment off).

## Tests
- **core** `getLiveMatches` windowing: adjacent-bucket match found; HT in, FT/SCHEDULED out; window-less fallback; degrade-to-empty.
- **cli** refresher integration: a stubbed ESPN feed whose no-date bucket is all-FT — asserts the cache persists the in-play match (the statusline regression).
- Verified live: rebuilt `live` + statusline both show `⚽ 🇦🇹 2–1 🇯🇴 88'`.

Full gate green: core 151 · mcp 50 · cli 141 · typecheck · lint.