### PR TITLE
Cursor Marketplace plugin (MCP server)

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "claudinho",
+  "description": "Live 2026 World Cup scores, fixtures, and group standings for your Cursor agent — a read-only MCP server. No API keys. Pairs with the Claudinho Cursor CLI statusline. Independent fan project, not affiliated with FIFA or Anthropic.",
+  "version": "0.6.0",
+  "author": { "name": "Arturo Garrido" },
+  "homepage": "https://github.com/arturogarrido/claudinho#readme",
+  "repository": "https://github.com/arturogarrido/claudinho",
+  "license": "MIT",
+  "keywords": [
+    "world-cup",
+    "football",
+    "soccer",
+    "live-scores",
+    "fixtures",
+    "standings",
+    "mcp",
+    "sports"
+  ],
+  "logo": ".github/assets/logo-400.png"
+}

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "claudinho": {
+      "command": "npx",
+      "args": ["-y", "@claudinho/mcp"]
+    }
+  }
+}


### PR DESCRIPTION
Packages the `@claudinho/mcp` server as an official **Cursor plugin** for [cursor.com/marketplace](https://cursor.com/marketplace) — a distinct, durable, first-party Cursor surface (separate from the community cursor.directory and the cross-client MCP Registry). This is channel **C3** from the Cursor-push plan.

## What's in it
- **`.cursor-plugin/plugin.json`** — the plugin manifest (kebab-case `name: claudinho`, MIT, repo/homepage, keywords, logo via relative path).
- **`mcp.json`** (repo root) — auto-discovered MCP config → `npx -y @claudinho/mcp`.

## Design decisions
- **MCP-only.** The `beforeSubmitPrompt` hook is intentionally **omitted** — Cursor can't reliably inject hook context yet (the deferred feature). The **statusline isn't a plugin primitive** either. Both are mentioned in the description, not shipped as broken parts. Shipping the honest, working core.

## Verified against ground truth (cursor.com/docs/reference/plugins)
- Manifest rules pass: kebab-case name, relative logo path that exists, required fields present.
- `mcp.json` matches the documented `{ "mcpServers": { name: { command, args } } }` format exactly.
- **Functional test:** `npx -y @claudinho/mcp` launches and serves **all 7 tools** end-to-end (`get_today, get_live, get_match, get_standings, get_next_fixture, get_market_signal, get_share_snippet`).
- Installed locally at `~/.cursor/plugins/local/claudinho/` for in-app verification.

## To verify + ship (Arturo)
1. Cursor → **Developer: Reload Window** → confirm the `claudinho` MCP server (7 tools) appears.
2. Merge this PR (plugin must be on `main` for the review).
3. Submit the repo at **cursor.com/marketplace/publish** (manual open-source review).

No code paths touched; lint green. Nothing submitted to Cursor — that's your step.