### PR TITLE
feat(cli): 3-letter-code fallback for flagless terminals (Warp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ emits the snippets, or copy them straight from here:
 ```bash
 export CLAUDINHO_CURSOR_META=auto   # model + context % line under the score (recommended)
 export CLAUDINHO_TEAM=MEX           # show only your team's match
+export CLAUDINHO_FLAGS=off          # 3-letter codes instead of flag emoji (auto-on for Warp)
 ```
 
 > **Note:** Cursor's `beforeSubmitPrompt` hook doesn't yet reliably inject context into the
@@ -162,7 +163,13 @@ _Planned (not shipped yet):_ a desktop notifier and an AI pundit with a public a
 
 **Why no crests, kits, or player photos?** Legal-clean by design: facts and emoji flags only.
 
-**Windows?** Works, but flag emoji rendering varies by terminal — best on macOS/Linux.
+**Flags show as boxed letters (`CH`, `BA`)?** Some terminals — notably Warp — don't compose
+the regional-indicator pairs into flag glyphs, so 🇨🇭 renders as a boxed `CH`. claudinho
+auto-detects Warp and falls back to 3-letter codes (`MEX 1–0 RSA 67'`) on the statusline and
+hook. Force it anywhere with `CLAUDINHO_FLAGS=off`, or keep flags with `CLAUDINHO_FLAGS=on`.
+
+**Windows?** Works, but flag emoji rendering varies by terminal — best on macOS/Linux. See the
+flags note above; `CLAUDINHO_FLAGS=off` gives clean codes on any terminal that can't render them.
 
 ## License
 

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -58,7 +58,7 @@ import type {
   ShareStyle,
 } from '@claudinho/core';
 import { readCurrentState } from './cache';
-import { liveMatchesFromCache, renderPrompt } from './statusline';
+import { flagsEnabled, liveMatchesFromCache, renderPrompt } from './statusline';
 import { renderHook } from './hook';
 import { runRefresh, shouldRefresh, spawnRefresh } from './refresh';
 import { readCursorPayload, renderPromptOutput } from './cursorPayload';
@@ -399,7 +399,7 @@ export function cmdPrompt({ cfg }: Ctx): void {
     const max = Number.isFinite(maxRaw) && maxRaw > 0 ? maxRaw : undefined;
     // Only trust a snapshot fetched for the current source + competition.
     const state = readCurrentState(cfg.source, resolveCompetition());
-    const scoreLine = renderPrompt(state, { team, compact, max });
+    const scoreLine = renderPrompt(state, { team, compact, max, flags: flagsEnabled() });
     out(renderPromptOutput(scoreLine, payload));
     if (!state || shouldRefresh()) spawnRefresh(cfg.source);
   } catch {
@@ -419,7 +419,7 @@ export function cmdHook({ cfg }: Ctx): void {
     const team = process.env.CLAUDINHO_TEAM;
     // Only trust a snapshot fetched for the current source + competition.
     const state = readCurrentState(cfg.source, resolveCompetition());
-    const ctx = renderHook(state, { team });
+    const ctx = renderHook(state, { team, flags: flagsEnabled() });
     if (ctx) out(ctx);
     if (!state || shouldRefresh()) spawnRefresh(cfg.source);
   } catch {

--- a/packages/cli/src/hook.ts
+++ b/packages/cli/src/hook.ts
@@ -17,12 +17,16 @@ import { liveMatchesFromCache } from './statusline';
 export interface HookOpts {
   /** Preferred team code (e.g. "MEX") — listed first. */
   team?: string;
+  /** Render emoji flags (default true); false → names only, for flagless terminals. */
+  flags?: boolean;
   now?: Date;
 }
 
-function line(m: Match): string {
+function line(m: Match, flags: boolean): string {
   const minute = m.status === 'HT' ? 'half-time' : m.minute ? `${m.minute}'` : 'live';
-  return `${m.home.flag} ${m.home.name} ${scoreline(m)} ${m.away.name} ${m.away.flag} (${minute})`;
+  const home = flags ? `${m.home.flag} ${m.home.name}` : m.home.name;
+  const away = flags ? `${m.away.name} ${m.away.flag}` : m.away.name;
+  return `${home} ${scoreline(m)} ${away} (${minute})`;
 }
 
 /**
@@ -36,6 +40,7 @@ export function renderHook(
 ): string {
   const now = opts.now ?? new Date();
   const team = opts.team?.toUpperCase();
+  const flags = opts.flags ?? true;
 
   let live = liveMatchesFromCache(state, now.getTime());
   if (live.length === 0) return '';
@@ -49,7 +54,7 @@ export function renderHook(
     });
   }
 
-  const lines = live.map(line).join('\n');
+  const lines = live.map((mm) => line(mm, flags)).join('\n');
   // Labelled as live context so the model treats it as ambient info, not an
   // instruction. Kept terse to minimise token cost.
   return `[Claudinho — live football scores right now]\n${lines}`;

--- a/packages/cli/src/statusline.ts
+++ b/packages/cli/src/statusline.ts
@@ -23,6 +23,26 @@ import { ageMs, type CacheState } from './cache';
 export { LIVE_WINDOW_MS };
 /** Don't display cached live scores older than this (avoid stale scores). */
 export const DISPLAY_STALE_MS = 5 * 60_000;
+
+/**
+ * Terminals whose renderer doesn't compose regional-indicator pairs into flag
+ * emoji — they show the boxed letters instead (🇨🇭 → "CH", 🇧🇦 → "BA"), which is
+ * noisier than the plain 3-letter code. We default these to codes.
+ */
+const FLAGLESS_TERMINALS = new Set(['WarpTerminal']);
+
+/**
+ * Whether to render emoji flags in the statusline/hook. Explicit CLAUDINHO_FLAGS
+ * wins (on/off); otherwise auto — off on a terminal known not to render flag
+ * emoji (e.g. Warp), on everywhere else. Pure given an env snapshot so callers
+ * resolve it once and pass the boolean into the (env-free) render functions.
+ */
+export function flagsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = (env.CLAUDINHO_FLAGS ?? '').trim().toLowerCase();
+  if (v === 'off' || v === '0' || v === 'no' || v === 'false') return false;
+  if (v === 'on' || v === '1' || v === 'yes' || v === 'true') return true;
+  return !FLAGLESS_TERMINALS.has(env.TERM_PROGRAM ?? '');
+}
 /** Refresh the cache when it's older than this during a live window. */
 export const LIVE_TTL_MS = 15_000;
 
@@ -46,12 +66,25 @@ export interface PromptOpts {
    * Default: show all. (CLAUDINHO_MAX caps it for busy days.)
    */
   max?: number;
+  /** Render emoji flags (default true); false → 3-letter codes (flagless terminals). */
+  flags?: boolean;
   now?: Date;
 }
 
+/** A team's compact token: emoji flag, or its 3-letter code when flags are off. */
+function teamTok(t: { code: string; flag: string }, flags: boolean): string {
+  return flags ? t.flag : t.code;
+}
+
 /** One match as a segment (no leading icon), e.g. "🇪🇸 1–1 🇮🇶 87'". */
-function matchSegment(m: Match, compact: boolean): string {
+function matchSegment(m: Match, compact: boolean, flags: boolean): string {
   const minute = m.status === 'HT' ? 'HT' : m.minute ? `${m.minute}'` : 'LIVE';
+  if (!flags) {
+    // Codes only — a flagless terminal would render the flag as boxed letters,
+    // so the code already carries that info without the noise. Compact and
+    // non-compact converge here (the code is the whole token).
+    return `${m.home.code} ${scoreline(m)} ${m.away.code} ${minute}`;
+  }
   const home = compact ? m.home.flag : `${m.home.flag} ${m.home.code}`;
   const away = compact ? m.away.flag : `${m.away.code} ${m.away.flag}`;
   return `${home} ${scoreline(m)} ${away} ${minute}`;
@@ -83,6 +116,7 @@ export function renderPrompt(state: CacheState | undefined, opts: PromptOpts = {
   const now = opts.now ?? new Date();
   const nowMs = now.getTime();
   const compact = opts.compact ?? true;
+  const flags = opts.flags ?? true;
   const team = opts.team?.toUpperCase();
 
   const live = liveMatchesFromCache(state, nowMs);
@@ -90,13 +124,13 @@ export function renderPrompt(state: CacheState | undefined, opts: PromptOpts = {
   // With a team filter, show only that team's live match.
   if (team) {
     const mine = live.find((m) => m.home?.code === team || m.away?.code === team);
-    if (mine) return `⚽ ${matchSegment(mine, compact)}`;
+    if (mine) return `⚽ ${matchSegment(mine, compact, flags)}`;
   } else if (live.length > 0) {
     // No filter → show all live matches inline, separated by " · ".
     // CLAUDINHO_MAX caps how many render before the rest collapse to "+N".
     const max = opts.max && opts.max > 0 ? opts.max : live.length;
     const shown = live.slice(0, max);
-    let line = '⚽ ' + shown.map((m) => matchSegment(m, compact)).join(' · ');
+    let line = '⚽ ' + shown.map((m) => matchSegment(m, compact, flags)).join(' · ');
     const overflow = live.length - shown.length;
     if (overflow > 0) line += ` +${overflow}`;
     return line;
@@ -119,7 +153,7 @@ export function renderPrompt(state: CacheState | undefined, opts: PromptOpts = {
     if (first) {
       const more = win.length - 1;
       return (
-        `⚽ ${first.home.flag} vs ${first.away.flag} live · syncing…` +
+        `⚽ ${teamTok(first.home, flags)} vs ${teamTok(first.away, flags)} live · syncing…` +
         (more > 0 ? ` +${more}` : '')
       );
     }
@@ -128,7 +162,7 @@ export function renderPrompt(state: CacheState | undefined, opts: PromptOpts = {
   // Nothing (relevant) live → next-fixture countdown (pure static).
   const next = team ? nextFixtureForTeam(team, { from: now }) : nextOverall(nowMs);
   if (next) {
-    return `${next.home.flag} vs ${next.away.flag} in ${countdown(next.kickoff, now)}`;
+    return `${teamTok(next.home, flags)} vs ${teamTok(next.away, flags)} in ${countdown(next.kickoff, now)}`;
   }
   return '⚽ —';
 }

--- a/packages/cli/test/hook.test.ts
+++ b/packages/cli/test/hook.test.ts
@@ -42,6 +42,13 @@ describe('renderHook', () => {
     expect(out).toContain("(67')");
   });
 
+  it('drops flag emoji (names only) when flags are off', () => {
+    const s = state([m(['MEX', '🇲🇽'], ['RSA', '🇿🇦'], { minute: 67, score: { home: 1, away: 0 } })]);
+    const out = renderHook(s, { now: NOW, flags: false });
+    expect(out).toContain('MEX 1–0 RSA');
+    expect(out).not.toMatch(/\uD83C[\uDDE6-\uDDFF]/); // no regional-indicator flag
+  });
+
   it('renders half-time as a word, not a minute', () => {
     const s = state([m(['MEX', '🇲🇽'], ['RSA', '🇿🇦'], { status: 'HT', score: { home: 0, away: 0 } })]);
     expect(renderHook(s, { now: NOW })).toContain('(half-time)');

--- a/packages/cli/test/hotpath.test.ts
+++ b/packages/cli/test/hotpath.test.ts
@@ -51,6 +51,7 @@ const origCache = process.env.XDG_CACHE_HOME;
 const origComp = process.env.CLAUDINHO_COMPETITION;
 const origTeam = process.env.CLAUDINHO_TEAM;
 const origMeta = process.env.CLAUDINHO_CURSOR_META;
+const origFlags = process.env.CLAUDINHO_FLAGS;
 let outSpy: ReturnType<typeof vi.spyOn>;
 let writes: string[] = [];
 
@@ -60,6 +61,9 @@ beforeEach(() => {
   delete process.env.CLAUDINHO_COMPETITION;
   delete process.env.CLAUDINHO_TEAM;
   process.env.CLAUDINHO_CURSOR_META = 'auto';
+  // Pin flags on so these assertions hold regardless of the host terminal
+  // (the flag auto-detect would otherwise switch to codes under e.g. Warp).
+  process.env.CLAUDINHO_FLAGS = 'on';
   writes = [];
   outSpy = vi.spyOn(process.stdout, 'write').mockImplementation((c: unknown) => {
     writes.push(String(c));
@@ -83,6 +87,8 @@ afterEach(() => {
   else process.env.CLAUDINHO_TEAM = origTeam;
   if (origMeta === undefined) delete process.env.CLAUDINHO_CURSOR_META;
   else process.env.CLAUDINHO_CURSOR_META = origMeta;
+  if (origFlags === undefined) delete process.env.CLAUDINHO_FLAGS;
+  else process.env.CLAUDINHO_FLAGS = origFlags;
   rmSync(dir, { recursive: true, force: true });
 });
 

--- a/packages/cli/test/statusline.test.ts
+++ b/packages/cli/test/statusline.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { inLiveWindow, renderPrompt } from '../src/statusline';
+import { flagsEnabled, inLiveWindow, renderPrompt } from '../src/statusline';
 import type { CacheState } from '../src/cache';
 import type { Match } from '@claudinho/core';
 
@@ -117,6 +117,48 @@ describe('renderPrompt — next fixture (static, no cache)', () => {
   it('shows a specific team next fixture when configured', () => {
     const line = renderPrompt(undefined, { now: PRE, team: 'BRA' });
     expect(line.startsWith('🇧🇷 vs 🇲🇦 in ')).toBe(true); // Brazil v Morocco
+  });
+});
+
+describe('flagsEnabled', () => {
+  it('honors an explicit off/on (any common spelling)', () => {
+    for (const v of ['off', '0', 'no', 'false', 'OFF']) {
+      expect(flagsEnabled({ CLAUDINHO_FLAGS: v })).toBe(false);
+    }
+    for (const v of ['on', '1', 'yes', 'true', 'ON']) {
+      expect(flagsEnabled({ CLAUDINHO_FLAGS: v })).toBe(true);
+    }
+  });
+
+  it('auto-detects a flagless terminal (Warp) when unset', () => {
+    expect(flagsEnabled({ TERM_PROGRAM: 'WarpTerminal' })).toBe(false);
+  });
+
+  it('defaults to flags-on for other terminals / no hint', () => {
+    expect(flagsEnabled({ TERM_PROGRAM: 'iTerm.app' })).toBe(true);
+    expect(flagsEnabled({})).toBe(true);
+  });
+
+  it('lets an explicit setting override the Warp auto-detect', () => {
+    expect(flagsEnabled({ TERM_PROGRAM: 'WarpTerminal', CLAUDINHO_FLAGS: 'on' })).toBe(true);
+  });
+});
+
+describe('renderPrompt — flags off (codes instead of emoji)', () => {
+  it('renders 3-letter codes and no flag emoji for a live match', () => {
+    const s = state([m('1', ['MEX', '🇲🇽'], ['RSA', '🇿🇦'], { minute: 67, score: { home: 1, away: 0 } })]);
+    expect(renderPrompt(s, { now: NOW, flags: false })).toBe("⚽ MEX 1–0 RSA 67'");
+  });
+
+  it('uses codes in the countdown fallback too', () => {
+    const PRE = new Date('2026-06-01T00:00:00Z');
+    const line = renderPrompt(undefined, { now: PRE, flags: false });
+    expect(line.startsWith('MEX vs RSA in ')).toBe(true);
+    expect(line).not.toMatch(/\uD83C[\uDDE6-\uDDFF]/); // no regional-indicator flag
+  });
+
+  it('uses codes in the "syncing" line during a cold live window', () => {
+    expect(renderPrompt(undefined, { now: NOW, flags: false })).toContain('MEX vs RSA live · syncing');
   });
 });
 


### PR DESCRIPTION
Closes #26 
Flag emoji are regional-indicator pairs (🇨🇭 = C+H). Some terminal renderers — notably Warp — don't compose them into a flag glyph and show the boxed letters, so the Claude Code statusline reads "⚽ CH 0–0 BA 44'" instead of "⚽ 🇨🇭 0–0 🇧🇦 44'".

Add CLAUDINHO_FLAGS=on|off plus auto-detection of flagless terminals (Warp, via TERM_PROGRAM), falling back to 3-letter codes on the statusline and hook. share snippets and MCP keep flags (portable artifacts that render in Slack/GitHub). Tests + README FAQ included.


