### PR TITLE
feat(cli): refresh schedule, extend flag fallback, knockout labels

### DIFF
--- a/.cursor-plugin/README.md
+++ b/.cursor-plugin/README.md
@@ -1,0 +1,59 @@
+# Claudinho — Cursor Marketplace plugin
+
+**MCP-only.** This folder is the Cursor Marketplace manifest for the
+[`claudinho`](https://github.com/arturogarrido/claudinho) monorepo. The npm
+package is [`@claudinho/mcp`](https://www.npmjs.com/package/@claudinho/mcp).
+
+## What installs
+
+| Shipped in plugin | Not shipped (by design) |
+|-------------------|-------------------------|
+| MCP server via `../mcp.json` → `npx -y @claudinho/mcp` | Cursor CLI **statusline** (separate: `@claudinho/cli`) |
+| 7 read-only tools (see below) | **Hook** / score-aware prompt injection (Cursor `beforeSubmitPrompt` unreliable) |
+| Resources + prompts | Betting links or trade calls |
+
+## MCP tools (7)
+
+- `get_today` — fixtures for a date (default today), live overlay
+- `get_live` — matches in play now
+- `get_match` — one match by id
+- `get_standings` — group table(s) A–L or all
+- `get_next_fixture` — team's next match (offline schedule)
+- `get_market_signal` — read-only market-implied % (informational only)
+- `get_share_snippet` — copy-paste plain-text card
+
+All tools: `readOnlyHint`, optional `tz` / `lang` / `flavor`. No API keys.
+
+## Verify locally
+
+```bash
+git clone https://github.com/arturogarrido/claudinho.git
+cp -R claudinho ~/.cursor/plugins/local/claudinho
+# Cursor → Developer: Reload Window
+# Settings → MCP → confirm `claudinho` lists 7 tools
+```
+
+Or run the server directly:
+
+```bash
+npx -y @claudinho/mcp
+```
+
+Tests: `packages/mcp/test/cursor-plugin.test.ts`, `packages/mcp/test/manifest.test.ts`.
+
+## Statusline (optional companion)
+
+Not a plugin primitive. Users who want live scores in the Cursor CLI statusline:
+
+```bash
+npm i -g @claudinho/cli
+claudinho init cursor
+```
+
+## Data & compliance
+
+- Independent fan project — **not affiliated with FIFA or Anthropic**
+- MIT license, full source in this repo
+- Factual match data + emoji flags only (no crests, kits, footage, player likenesses)
+- Live scores: ESPN public scoreboard (attributed as `Live data: ESPN`)
+- Market line: optional, read-only Polymarket signal — **not betting advice**; off via `CLAUDINHO_MARKETS=off`

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 ```bash
 npx @claudinho/cli today      # try it in 10 seconds — no install, no key
+npx @claudinho/cli live       # what's on right now (during match windows)
 ```
 
 While matches are live, your Claude Code or Cursor CLI statusline reads:
@@ -166,7 +167,7 @@ _Planned (not shipped yet):_ a desktop notifier and an AI pundit with a public a
 **Flags show as boxed letters (`CH`, `BA`)?** Some terminals — notably Warp — don't compose
 the regional-indicator pairs into flag glyphs, so 🇨🇭 renders as a boxed `CH`. claudinho
 auto-detects Warp and drops the flags: **3-letter codes on the statusline** (`MEX 1–0 RSA 67'`)
-and **plain team names in the hook**. Force it anywhere with `CLAUDINHO_FLAGS=off`, or keep flags
+and **plain team names in the hook**, `today` / `live` / `table`, and `next`. Force it anywhere with `CLAUDINHO_FLAGS=off`, or keep flags
 with `CLAUDINHO_FLAGS=on`.
 
 **Windows?** Works, but flag emoji rendering varies by terminal — best on macOS/Linux. See the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -166,7 +166,7 @@ network** (<150ms). When several matches are live it shows them all inline:
 - `CLAUDINHO_TEAM=MEX` — show only your team's match; also the default team for `next`, `markets next`, and `share next` when the argument is omitted
 - `CLAUDINHO_MAX=2` — cap how many live matches show inline (rest collapse to `+N`; default: all)
 - `CLAUDINHO_COMPACT=0` — show 3-letter codes alongside flags
-- `CLAUDINHO_FLAGS=off` — drop emoji flags for 3-letter codes (statusline) / plain names (hook); already automatic on terminals that can't render flag emoji, e.g. Warp
+- `CLAUDINHO_FLAGS=off` — drop emoji flags for 3-letter codes (statusline) / plain names (`today`, `live`, `table`, `next`, hook); already automatic on terminals that can't render flag emoji, e.g. Warp
 
 Use the same `claudinho prompt` in **tmux** (`set -g status-right '#(claudinho prompt)'`)
 or a **Starship** custom command — it works in any shell.

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -26,6 +26,7 @@ import {
   resolveCompetition,
   resolveMarketSource,
   scoreline,
+  stageLabel,
 } from '@claudinho/core';
 import Table from 'cli-table3';
 import type { CliConfig } from './config';
@@ -38,6 +39,7 @@ import {
   type Painter,
   painterFor,
   statusToken,
+  tableTeamCell,
 } from './format';
 import {
   getLiveMatches,
@@ -225,6 +227,7 @@ export async function cmdToday(date: string | undefined, ctx: Ctx): Promise<void
   }
 
   const c = painterFor(cfg);
+  const flags = flagsEnabled();
   // "Today's matches" only when no explicit date was given; otherwise "Matches".
   const title = date === undefined ? t('today.title') : t('today.on');
   out();
@@ -234,7 +237,7 @@ export async function cmdToday(date: string | undefined, ctx: Ctx): Promise<void
     out(c.dim('  ' + t('today.none')));
   } else {
     for (const m of todays) {
-      out(matchLine(m, cfg, t, c));
+      out(matchLine(m, cfg, t, c, flags));
       const s = signals.get(m.id);
       if (s) out('    ' + c.dim(marketLine(s, m)));
     }
@@ -260,6 +263,7 @@ export async function cmdLive(ctx: Ctx): Promise<void> {
   }
 
   const c = painterFor(cfg);
+  const flags = flagsEnabled();
   out();
   out(header(t('live.title'), c));
   out();
@@ -270,7 +274,7 @@ export async function cmdLive(ctx: Ctx): Promise<void> {
   } else if (matches.length === 0) {
     out(c.dim('  ' + t('live.none')));
   } else {
-    for (const m of matches) out(matchLine(m, cfg, t, c));
+    for (const m of matches) out(matchLine(m, cfg, t, c, flags));
   }
   out();
   const src = dataSource(source, c);
@@ -290,6 +294,7 @@ export async function cmdNext(team: string | undefined, { cfg, t, now }: Ctx): P
   }
 
   const c = painterFor(cfg);
+  const flags = flagsEnabled();
   out();
   if (!fixture) {
     out(c.dim('  ' + t('next.none', { team: code })));
@@ -299,11 +304,12 @@ export async function cmdNext(team: string | undefined, { cfg, t, now }: Ctx): P
   }
   out(header(t('next.label', { team: code }), c));
   out();
-  out(matchLine(fixture, cfg, t, c));
+  out(matchLine(fixture, cfg, t, c, flags));
+  const stage = fixture.stage !== 'GROUP' ? `${stageLabel(fixture)} · ` : '';
   out(
     '  ' +
       c.dim(
-        `${formatKickoff(fixture.kickoff, { tz: cfg.tz, locale: cfg.lang })} · ` +
+        `${stage}${formatKickoff(fixture.kickoff, { tz: cfg.tz, locale: cfg.lang })} · ` +
           t('next.in', { countdown: countdown(fixture.kickoff) }),
       ),
   );
@@ -332,6 +338,7 @@ export async function cmdTable(group: string | undefined, ctx: Ctx): Promise<voi
   }
 
   const c = painterFor(cfg);
+  const flags = flagsEnabled();
   if (tables.length === 0) {
     out();
     // A specific group that isn't there → "no group X"; no group asked (e.g. the
@@ -364,7 +371,7 @@ export async function cmdTable(group: string | undefined, ctx: Ctx): Promise<voi
     });
     for (const r of rows) {
       table.push([
-        `${r.team.flag} ${r.team.name}`,
+        tableTeamCell(r.team, flags),
         r.played,
         r.won,
         r.drawn,
@@ -556,9 +563,9 @@ export async function cmdMatch(id: string, ctx: Ctx): Promise<void> {
     out(disclaimer(t, c));
     return;
   }
-  const stageLabel = match.group ? `${match.stage} ${match.group}` : match.stage;
+  const stageLabelText = stageLabel(match);
   out(header(`${match.home.name} ${scoreline(match)} ${match.away.name}`, c));
-  out('  ' + c.dim(`${stageLabel} · ${matchLocation(match)}`));
+  out('  ' + c.dim(`${stageLabelText} · ${matchLocation(match)}`));
   out(
     '  ' +
       c.dim(

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -37,6 +37,11 @@ function paint(enabled: boolean) {
 
 export type Painter = ReturnType<typeof paint>;
 
+/** Team cell for standings tables. */
+export function tableTeamCell(team: { flag: string; name: string }, flags: boolean): string {
+  return flags ? `${team.flag} ${team.name}` : team.name;
+}
+
 export function painterFor(cfg: CliConfig): Painter {
   return paint(cfg.color);
 }
@@ -69,9 +74,10 @@ export function matchLine(
   cfg: CliConfig,
   t: Translator,
   c: Painter,
+  flags = true,
 ): string {
-  const home = `${m.home.flag} ${m.home.name}`;
-  const away = `${m.away.name} ${m.away.flag}`;
+  const home = flags ? `${m.home.flag} ${m.home.name}` : m.home.name;
+  const away = flags ? `${m.away.name} ${m.away.flag}` : m.away.name;
   const mid = isLive(m.status) || m.status === 'FT'
     ? c.bold(scoreline(m))
     : c.dim('vs');

--- a/packages/cli/test/format.test.ts
+++ b/packages/cli/test/format.test.ts
@@ -45,4 +45,11 @@ describe('matchLine — flavor wiring', () => {
     const es = render(cfg({ flavor: 'full', lang: 'es' }));
     expect(es).toContain(matchFlavor(liveMatch(), { level: 'full', locale: 'es' }));
   });
+
+  it('drops flag emoji when flags are off (names only)', () => {
+    const line = matchLine(liveMatch(), cfg(), makeT('en'), painterFor(cfg()), false);
+    expect(line).toContain('Mexico');
+    expect(line).toContain('South Africa');
+    expect(line).not.toMatch(/\uD83C[\uDDE6-\uDDFF]/);
+  });
 });

--- a/packages/cli/test/markets.test.ts
+++ b/packages/cli/test/markets.test.ts
@@ -34,7 +34,11 @@ const synth = () => new FakeMarketProvider({ synthesize: true, now: TEST_NOW });
 
 /** A fixture still upcoming at TEST_NOW (its market read is relevant). */
 const upcoming = (): Match =>
-  allFixtures().find((m) => Date.parse(m.kickoff) > TEST_NOW.getTime())!;
+  allFixtures().find(
+    (m) => m.status === 'SCHEDULED' && Date.parse(m.kickoff) > TEST_NOW.getTime(),
+  )!;
+
+const upcomingDate = () => upcoming().kickoff.slice(0, 10);
 
 function cfg(over: Partial<CliConfig> = {}): CliConfig {
   return { lang: 'en', tz: 'UTC', json: true, color: false, source: 'espn', flavor: 'off', ...over };
@@ -63,13 +67,13 @@ const text = () => writes.join('');
 
 describe('cmdMarkets — date listing', () => {
   it('emits a sidecar JSON shape keyed by matchId', async () => {
-    await cmdMarkets('2026-06-13', undefined, ctx({ json: true }, synth()));
+    await cmdMarkets(upcomingDate(), undefined, ctx({ json: true }, synth()));
     const data = json() as {
       date: string;
       informationalOnly: boolean;
       marketSignals: Record<string, { source: string; matchId: string }>;
     };
-    expect(data.date).toBe('2026-06-13');
+    expect(data.date).toBe(upcomingDate());
     expect(data.informationalOnly).toBe(true);
     const ids = Object.keys(data.marketSignals);
     expect(ids.length).toBeGreaterThan(0);
@@ -78,9 +82,9 @@ describe('cmdMarkets — date listing', () => {
   });
 
   it('renders attribution + dual disclaimers and no betting language', async () => {
-    await cmdMarkets('2026-06-13', undefined, ctx({ json: false }, synth()));
+    await cmdMarkets(upcomingDate(), undefined, ctx({ json: false }, synth()));
     const o = text();
-    expect(o).toContain('Market signals · 2026-06-13');
+    expect(o).toContain(`Market signals · ${upcomingDate()}`);
     expect(o).toContain('informational only');
     expect(o).toContain('Not affiliated with FIFA or Anthropic.');
     expect(o).toContain('Prediction-market data is informational only.');
@@ -168,10 +172,9 @@ describe('cmdMarkets — next <team>', () => {
   });
 
   it("prefers the team's IN-PLAY match over their next fixture", async () => {
-    // Mid-opener clock: the first fixture is being played right now.
-    const opener = allFixtures()[0]!;
-    const during = new Date(Date.parse(opener.kickoff) + 30 * 60_000);
-    await cmdMarkets('next', opener.home.code, ctx({ json: true }, synth(), during));
-    expect((json() as { matchId: string }).matchId).toBe(opener.id);
+    const fixture = upcoming();
+    const during = new Date(Date.parse(fixture.kickoff) + 30 * 60_000);
+    await cmdMarkets('next', fixture.home.code, ctx({ json: true }, synth(), during));
+    expect((json() as { matchId: string }).matchId).toBe(fixture.id);
   });
 });

--- a/packages/cli/test/share.test.ts
+++ b/packages/cli/test/share.test.ts
@@ -44,6 +44,13 @@ const downAdapter: ProviderAdapter = {
 // deterministic after these fixtures fall into the real past.
 const TEST_NOW = new Date('2026-06-13T12:00:00Z');
 
+const upcoming = (): Match =>
+  allFixtures().find(
+    (m) => m.status === 'SCHEDULED' && Date.parse(m.kickoff) > TEST_NOW.getTime(),
+  )!;
+
+const upcomingDate = () => upcoming().kickoff.slice(0, 10);
+
 /** A fresh, cleanly-mapped, reliable signal for a given match. */
 const freshSig = (m: Match): MarketSignal => ({
   matchId: m.id,
@@ -115,7 +122,7 @@ const json = () => JSON.parse(writes.join(''));
 const HASHTAG = '#VibingLaVidaLoca';
 const DISCLAIMER = 'not affiliated with FIFA or Anthropic';
 const BANNED = /\b(bet|betting|wager|gambling|edge|lock|value pick)\b/i;
-const aTeam = () => allFixtures()[0]!.home.code;
+const aTeam = () => upcoming().home.code;
 
 describe('cmdShare — routing & JSON', () => {
   it('share next <team> --json carries the structured shape', async () => {
@@ -180,7 +187,7 @@ describe('cmdShare — toggles & styles', () => {
   });
 
   it('--style compact uses 3-letter codes and no venue', async () => {
-    await cmdShare('2026-06-13', undefined, { style: 'compact' }, ctx());
+    await cmdShare(upcomingDate(), undefined, { style: 'compact' }, ctx());
     const o = text();
     expect(o).toMatch(/[A-Z]{3} vs [A-Z]{3}/);
     expect(o).not.toContain('Estadio');
@@ -190,7 +197,17 @@ describe('cmdShare — toggles & styles', () => {
 
 describe('cmdShare — market gating (fail closed)', () => {
   it('includes a reliable market block', async () => {
-    await cmdShare('next', aTeam(), {}, ctx({}, provider(freshSig)));
+    const fixture = upcoming();
+    const before = new Date(Date.parse(fixture.kickoff) - 3_600_000);
+    const sig = (m: Match): MarketSignal => ({
+      ...freshSig(m),
+      asOf: before.toISOString(),
+      fetchedAt: before.toISOString(),
+    });
+    await cmdShare('next', fixture.home.code, {}, {
+      ...ctx({}, provider((m) => (m.id === fixture.id ? sig(m) : undefined))),
+      now: before,
+    });
     expect(text()).toContain('informational only');
   });
 

--- a/packages/core/scripts/build-schedule.ts
+++ b/packages/core/scripts/build-schedule.ts
@@ -4,13 +4,15 @@
  *   pnpm -F @claudinho/core gen:schedule
  *
  * Fetches the full tournament window in weekly chunks, dedupes by id, sorts by
- * kickoff, and writes src/data/schedule.2026.json. Re-run as the bracket fills
- * in (knockout fixtures resolve from TBD to real teams).
+ * kickoff, and writes src/data/schedule.2026.json. Live scores and final
+ * results are stripped — the bundle is a resultless skeleton; only team names,
+ * kickoffs, venues, and bracket structure ship in the package.
  */
 import { writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { EspnAdapter } from '../src/adapters/espn';
+import { sanitizeBundledFixture } from '../src/schedule';
 import type { Match } from '../src/types';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -40,9 +42,17 @@ async function main(): Promise<void> {
     }
   }
 
-  const all = [...byId.values()].sort((a, b) => a.kickoff.localeCompare(b.kickoff));
+  const all = [...byId.values()]
+    .map(sanitizeBundledFixture)
+    .sort((a, b) => a.kickoff.localeCompare(b.kickoff));
 
-  // ---- sanity checks: fail loudly rather than write garbage ----
+  const problems: string[] = [];
+  const withResults = all.filter((m) => m.status !== 'SCHEDULED' || m.score != null);
+  if (withResults.length > 0) {
+    problems.push(
+      `bundled schedule must be resultless: ${withResults.length} fixture(s) still carry status/score after sanitize`,
+    );
+  }
   const stageCounts = all.reduce<Record<string, number>>((acc, m) => {
     acc[m.stage] = (acc[m.stage] ?? 0) + 1;
     return acc;
@@ -52,7 +62,6 @@ async function main(): Promise<void> {
     GROUP: 72, R32: 16, R16: 8, QF: 4, SF: 2, '3P': 1, F: 1,
   };
 
-  const problems: string[] = [];
   if (all.length !== 104) problems.push(`expected 104 fixtures, got ${all.length}`);
   if (groupLetters.size !== 12) {
     problems.push(`expected 12 groups, got ${groupLetters.size} (${[...groupLetters].sort().join(',')})`);

--- a/packages/core/src/data/schedule.2026.json
+++ b/packages/core/src/data/schedule.2026.json
@@ -17,12 +17,8 @@
       "name": "South Africa",
       "flag": "🇿🇦"
     },
-    "score": {
-      "home": 2,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.385Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.527Z"
   },
   {
     "id": "760414",
@@ -42,12 +38,8 @@
       "name": "Czechia",
       "flag": "🇨🇿"
     },
-    "score": {
-      "home": 2,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760416",
@@ -67,12 +59,8 @@
       "name": "Bosnia-Herzegovina",
       "flag": "🇧🇦"
     },
-    "score": {
-      "home": 1,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760417",
@@ -92,12 +80,8 @@
       "name": "Paraguay",
       "flag": "🇵🇾"
     },
-    "score": {
-      "home": 4,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760420",
@@ -117,12 +101,8 @@
       "name": "Switzerland",
       "flag": "🇨🇭"
     },
-    "score": {
-      "home": 1,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760419",
@@ -142,12 +122,8 @@
       "name": "Morocco",
       "flag": "🇲🇦"
     },
-    "score": {
-      "home": 1,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760418",
@@ -167,12 +143,8 @@
       "name": "Scotland",
       "flag": "🏴󠁧󠁢󠁳󠁣󠁴󠁿"
     },
-    "score": {
-      "home": 0,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760421",
@@ -192,12 +164,8 @@
       "name": "Türkiye",
       "flag": "🇹🇷"
     },
-    "score": {
-      "home": 2,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760422",
@@ -217,12 +185,8 @@
       "name": "Curaçao",
       "flag": "🇨🇼"
     },
-    "score": {
-      "home": 7,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760425",
@@ -242,12 +206,8 @@
       "name": "Japan",
       "flag": "🇯🇵"
     },
-    "score": {
-      "home": 2,
-      "away": 2
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760423",
@@ -267,12 +227,8 @@
       "name": "Ecuador",
       "flag": "🇪🇨"
     },
-    "score": {
-      "home": 1,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760424",
@@ -292,12 +248,8 @@
       "name": "Tunisia",
       "flag": "🇹🇳"
     },
-    "score": {
-      "home": 5,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760428",
@@ -317,12 +269,8 @@
       "name": "Cape Verde",
       "flag": "🇨🇻"
     },
-    "score": {
-      "home": 0,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760426",
@@ -342,12 +290,8 @@
       "name": "Egypt",
       "flag": "🇪🇬"
     },
-    "score": {
-      "home": 1,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760429",
@@ -367,12 +311,8 @@
       "name": "Uruguay",
       "flag": "🇺🇾"
     },
-    "score": {
-      "home": 1,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760427",
@@ -392,12 +332,8 @@
       "name": "New Zealand",
       "flag": "🇳🇿"
     },
-    "score": {
-      "home": 2,
-      "away": 2
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760432",
@@ -417,12 +353,8 @@
       "name": "Senegal",
       "flag": "🇸🇳"
     },
-    "score": {
-      "home": 3,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760430",
@@ -442,12 +374,8 @@
       "name": "Norway",
       "flag": "🇳🇴"
     },
-    "score": {
-      "home": 1,
-      "away": 4
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760433",
@@ -467,12 +395,8 @@
       "name": "Algeria",
       "flag": "🇩🇿"
     },
-    "score": {
-      "home": 3,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760431",
@@ -492,12 +416,8 @@
       "name": "Jordan",
       "flag": "🇯🇴"
     },
-    "score": {
-      "home": 3,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760435",
@@ -517,12 +437,8 @@
       "name": "Congo DR",
       "flag": "🇨🇩"
     },
-    "score": {
-      "home": 1,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760437",
@@ -542,12 +458,8 @@
       "name": "Croatia",
       "flag": "🇭🇷"
     },
-    "score": {
-      "home": 4,
-      "away": 2
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760434",
@@ -567,12 +479,8 @@
       "name": "Panama",
       "flag": "🇵🇦"
     },
-    "score": {
-      "home": 1,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760436",
@@ -592,12 +500,8 @@
       "name": "Colombia",
       "flag": "🇨🇴"
     },
-    "score": {
-      "home": 1,
-      "away": 3
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.386Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.528Z"
   },
   {
     "id": "760438",
@@ -617,12 +521,8 @@
       "name": "South Africa",
       "flag": "🇿🇦"
     },
-    "score": {
-      "home": 1,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760439",
@@ -642,12 +542,8 @@
       "name": "Bosnia-Herzegovina",
       "flag": "🇧🇦"
     },
-    "score": {
-      "home": 4,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760440",
@@ -667,12 +563,8 @@
       "name": "Qatar",
       "flag": "🇶🇦"
     },
-    "score": {
-      "home": 6,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760441",
@@ -692,12 +584,8 @@
       "name": "South Korea",
       "flag": "🇰🇷"
     },
-    "score": {
-      "home": 1,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760442",
@@ -717,12 +605,8 @@
       "name": "Australia",
       "flag": "🇦🇺"
     },
-    "score": {
-      "home": 2,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760445",
@@ -742,12 +626,8 @@
       "name": "Morocco",
       "flag": "🇲🇦"
     },
-    "score": {
-      "home": 0,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760444",
@@ -767,12 +647,8 @@
       "name": "Haiti",
       "flag": "🇭🇹"
     },
-    "score": {
-      "home": 3,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760443",
@@ -792,12 +668,8 @@
       "name": "Paraguay",
       "flag": "🇵🇾"
     },
-    "score": {
-      "home": 0,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760447",
@@ -817,12 +689,8 @@
       "name": "Sweden",
       "flag": "🇸🇪"
     },
-    "score": {
-      "home": 5,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760448",
@@ -842,12 +710,8 @@
       "name": "Ivory Coast",
       "flag": "🇨🇮"
     },
-    "score": {
-      "home": 2,
-      "away": 1
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760446",
@@ -867,12 +731,8 @@
       "name": "Curaçao",
       "flag": "🇨🇼"
     },
-    "score": {
-      "home": 0,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760449",
@@ -892,12 +752,8 @@
       "name": "Japan",
       "flag": "🇯🇵"
     },
-    "score": {
-      "home": 0,
-      "away": 4
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760453",
@@ -917,12 +773,8 @@
       "name": "Saudi Arabia",
       "flag": "🇸🇦"
     },
-    "score": {
-      "home": 4,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760451",
@@ -942,12 +794,8 @@
       "name": "Iran",
       "flag": "🇮🇷"
     },
-    "score": {
-      "home": 0,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760450",
@@ -967,12 +815,8 @@
       "name": "Cape Verde",
       "flag": "🇨🇻"
     },
-    "score": {
-      "home": 2,
-      "away": 2
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760452",
@@ -992,12 +836,8 @@
       "name": "Egypt",
       "flag": "🇪🇬"
     },
-    "score": {
-      "home": 1,
-      "away": 3
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760456",
@@ -1017,12 +857,8 @@
       "name": "Austria",
       "flag": "🇦🇹"
     },
-    "score": {
-      "home": 2,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760457",
@@ -1042,12 +878,8 @@
       "name": "Iraq",
       "flag": "🇮🇶"
     },
-    "score": {
-      "home": 3,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760454",
@@ -1067,12 +899,8 @@
       "name": "Senegal",
       "flag": "🇸🇳"
     },
-    "score": {
-      "home": 3,
-      "away": 2
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760455",
@@ -1092,12 +920,8 @@
       "name": "Algeria",
       "flag": "🇩🇿"
     },
-    "score": {
-      "home": 1,
-      "away": 2
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760461",
@@ -1117,12 +941,8 @@
       "name": "Uzbekistan",
       "flag": "🇺🇿"
     },
-    "score": {
-      "home": 5,
-      "away": 0
-    },
-    "status": "FT",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "status": "SCHEDULED",
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760458",
@@ -1143,7 +963,7 @@
       "flag": "🇬🇭"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760460",
@@ -1164,7 +984,7 @@
       "flag": "🇭🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760459",
@@ -1185,7 +1005,7 @@
       "flag": "🇨🇩"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760462",
@@ -1206,7 +1026,7 @@
       "flag": "🇶🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760463",
@@ -1227,7 +1047,7 @@
       "flag": "🇨🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760464",
@@ -1248,7 +1068,7 @@
       "flag": "🇭🇹"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760465",
@@ -1269,7 +1089,7 @@
       "flag": "🇧🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760467",
@@ -1290,7 +1110,7 @@
       "flag": "🇲🇽"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760466",
@@ -1311,7 +1131,7 @@
       "flag": "🇰🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.490Z"
+    "updatedAt": "2026-06-23T22:15:03.624Z"
   },
   {
     "id": "760473",
@@ -1332,7 +1152,7 @@
       "flag": "🇨🇮"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760468",
@@ -1353,7 +1173,7 @@
       "flag": "🇩🇪"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760471",
@@ -1374,7 +1194,7 @@
       "flag": "🇸🇪"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760472",
@@ -1395,7 +1215,7 @@
       "flag": "🇳🇱"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760469",
@@ -1416,7 +1236,7 @@
       "flag": "🇦🇺"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760470",
@@ -1437,7 +1257,7 @@
       "flag": "🇺🇸"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760475",
@@ -1458,7 +1278,7 @@
       "flag": "🇫🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760474",
@@ -1479,7 +1299,7 @@
       "flag": "🇮🇶"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760478",
@@ -1500,7 +1320,7 @@
       "flag": "🇸🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760479",
@@ -1521,7 +1341,7 @@
       "flag": "🇪🇸"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760476",
@@ -1542,7 +1362,7 @@
       "flag": "🇮🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760477",
@@ -1563,7 +1383,7 @@
       "flag": "🇧🇪"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760480",
@@ -1584,7 +1404,7 @@
       "flag": "🇬🇭"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760485",
@@ -1605,7 +1425,7 @@
       "flag": "🏴󠁧󠁢󠁥󠁮󠁧󠁿"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760481",
@@ -1626,7 +1446,7 @@
       "flag": "🇵🇹"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760482",
@@ -1647,7 +1467,7 @@
       "flag": "🇺🇿"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760484",
@@ -1668,7 +1488,7 @@
       "flag": "🇦🇹"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760483",
@@ -1689,7 +1509,7 @@
       "flag": "🇦🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.575Z"
+    "updatedAt": "2026-06-23T22:15:03.692Z"
   },
   {
     "id": "760486",
@@ -1709,7 +1529,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.585Z"
+    "updatedAt": "2026-06-23T22:15:03.697Z"
   },
   {
     "id": "760487",
@@ -1729,7 +1549,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.585Z"
+    "updatedAt": "2026-06-23T22:15:03.697Z"
   },
   {
     "id": "760489",
@@ -1749,7 +1569,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.585Z"
+    "updatedAt": "2026-06-23T22:15:03.697Z"
   },
   {
     "id": "760488",
@@ -1769,7 +1589,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.585Z"
+    "updatedAt": "2026-06-23T22:15:03.697Z"
   },
   {
     "id": "760490",
@@ -1789,7 +1609,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.585Z"
+    "updatedAt": "2026-06-23T22:15:03.697Z"
   },
   {
     "id": "760492",
@@ -1809,7 +1629,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.585Z"
+    "updatedAt": "2026-06-23T22:15:03.697Z"
   },
   {
     "id": "760491",
@@ -1829,7 +1649,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.585Z"
+    "updatedAt": "2026-06-23T22:15:03.697Z"
   },
   {
     "id": "760495",
@@ -1849,7 +1669,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.585Z"
+    "updatedAt": "2026-06-23T22:15:03.697Z"
   },
   {
     "id": "760493",
@@ -1869,7 +1689,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.585Z"
+    "updatedAt": "2026-06-23T22:15:03.697Z"
   },
   {
     "id": "760494",
@@ -1889,7 +1709,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.585Z"
+    "updatedAt": "2026-06-23T22:15:03.697Z"
   },
   {
     "id": "760497",
@@ -1909,7 +1729,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760496",
@@ -1929,7 +1749,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760498",
@@ -1949,7 +1769,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760499",
@@ -1969,7 +1789,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760500",
@@ -1989,7 +1809,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760501",
@@ -2009,7 +1829,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760502",
@@ -2029,7 +1849,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760503",
@@ -2049,7 +1869,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760504",
@@ -2069,7 +1889,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760505",
@@ -2089,7 +1909,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760506",
@@ -2109,7 +1929,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760507",
@@ -2129,7 +1949,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760509",
@@ -2149,7 +1969,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760508",
@@ -2169,7 +1989,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.664Z"
+    "updatedAt": "2026-06-23T22:15:03.762Z"
   },
   {
     "id": "760510",
@@ -2189,7 +2009,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.747Z"
+    "updatedAt": "2026-06-23T22:15:03.862Z"
   },
   {
     "id": "760511",
@@ -2209,7 +2029,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.747Z"
+    "updatedAt": "2026-06-23T22:15:03.862Z"
   },
   {
     "id": "760512",
@@ -2229,7 +2049,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.747Z"
+    "updatedAt": "2026-06-23T22:15:03.862Z"
   },
   {
     "id": "760513",
@@ -2249,7 +2069,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.747Z"
+    "updatedAt": "2026-06-23T22:15:03.862Z"
   },
   {
     "id": "760514",
@@ -2269,7 +2089,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.747Z"
+    "updatedAt": "2026-06-23T22:15:03.862Z"
   },
   {
     "id": "760515",
@@ -2289,7 +2109,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.747Z"
+    "updatedAt": "2026-06-23T22:15:03.862Z"
   },
   {
     "id": "760516",
@@ -2309,7 +2129,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.830Z"
+    "updatedAt": "2026-06-23T22:15:03.932Z"
   },
   {
     "id": "760517",
@@ -2329,6 +2149,6 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-23T21:51:08.830Z"
+    "updatedAt": "2026-06-23T22:15:03.932Z"
   }
 ]

--- a/packages/core/src/data/schedule.2026.json
+++ b/packages/core/src/data/schedule.2026.json
@@ -17,8 +17,12 @@
       "name": "South Africa",
       "flag": "🇿🇦"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.333Z"
+    "score": {
+      "home": 2,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.385Z"
   },
   {
     "id": "760414",
@@ -38,8 +42,12 @@
       "name": "Czechia",
       "flag": "🇨🇿"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 2,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760416",
@@ -59,8 +67,12 @@
       "name": "Bosnia-Herzegovina",
       "flag": "🇧🇦"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 1,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760417",
@@ -80,8 +92,12 @@
       "name": "Paraguay",
       "flag": "🇵🇾"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 4,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760420",
@@ -101,8 +117,12 @@
       "name": "Switzerland",
       "flag": "🇨🇭"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 1,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760419",
@@ -122,8 +142,12 @@
       "name": "Morocco",
       "flag": "🇲🇦"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 1,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760418",
@@ -143,8 +167,12 @@
       "name": "Scotland",
       "flag": "🏴󠁧󠁢󠁳󠁣󠁴󠁿"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 0,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760421",
@@ -164,8 +192,12 @@
       "name": "Türkiye",
       "flag": "🇹🇷"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 2,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760422",
@@ -185,8 +217,12 @@
       "name": "Curaçao",
       "flag": "🇨🇼"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 7,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760425",
@@ -206,8 +242,12 @@
       "name": "Japan",
       "flag": "🇯🇵"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 2,
+      "away": 2
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760423",
@@ -227,8 +267,12 @@
       "name": "Ecuador",
       "flag": "🇪🇨"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 1,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760424",
@@ -248,8 +292,12 @@
       "name": "Tunisia",
       "flag": "🇹🇳"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 5,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760428",
@@ -269,8 +317,12 @@
       "name": "Cape Verde",
       "flag": "🇨🇻"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 0,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760426",
@@ -290,8 +342,12 @@
       "name": "Egypt",
       "flag": "🇪🇬"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 1,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760429",
@@ -311,8 +367,12 @@
       "name": "Uruguay",
       "flag": "🇺🇾"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 1,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760427",
@@ -332,8 +392,12 @@
       "name": "New Zealand",
       "flag": "🇳🇿"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 2,
+      "away": 2
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760432",
@@ -353,8 +417,12 @@
       "name": "Senegal",
       "flag": "🇸🇳"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 3,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760430",
@@ -374,8 +442,12 @@
       "name": "Norway",
       "flag": "🇳🇴"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 1,
+      "away": 4
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760433",
@@ -395,8 +467,12 @@
       "name": "Algeria",
       "flag": "🇩🇿"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 3,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760431",
@@ -416,8 +492,12 @@
       "name": "Jordan",
       "flag": "🇯🇴"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 3,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760435",
@@ -437,8 +517,12 @@
       "name": "Congo DR",
       "flag": "🇨🇩"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 1,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760437",
@@ -458,8 +542,12 @@
       "name": "Croatia",
       "flag": "🇭🇷"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 4,
+      "away": 2
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760434",
@@ -479,8 +567,12 @@
       "name": "Panama",
       "flag": "🇵🇦"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 1,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760436",
@@ -500,8 +592,12 @@
       "name": "Colombia",
       "flag": "🇨🇴"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.337Z"
+    "score": {
+      "home": 1,
+      "away": 3
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.386Z"
   },
   {
     "id": "760438",
@@ -521,8 +617,12 @@
       "name": "South Africa",
       "flag": "🇿🇦"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 1,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760439",
@@ -542,8 +642,12 @@
       "name": "Bosnia-Herzegovina",
       "flag": "🇧🇦"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 4,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760440",
@@ -563,8 +667,12 @@
       "name": "Qatar",
       "flag": "🇶🇦"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 6,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760441",
@@ -584,8 +692,12 @@
       "name": "South Korea",
       "flag": "🇰🇷"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 1,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760442",
@@ -605,8 +717,12 @@
       "name": "Australia",
       "flag": "🇦🇺"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 2,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760445",
@@ -626,8 +742,12 @@
       "name": "Morocco",
       "flag": "🇲🇦"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 0,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760444",
@@ -647,8 +767,12 @@
       "name": "Haiti",
       "flag": "🇭🇹"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 3,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760443",
@@ -668,8 +792,12 @@
       "name": "Paraguay",
       "flag": "🇵🇾"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 0,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760447",
@@ -689,8 +817,12 @@
       "name": "Sweden",
       "flag": "🇸🇪"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 5,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760448",
@@ -710,8 +842,12 @@
       "name": "Ivory Coast",
       "flag": "🇨🇮"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 2,
+      "away": 1
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760446",
@@ -731,8 +867,12 @@
       "name": "Curaçao",
       "flag": "🇨🇼"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 0,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760449",
@@ -752,8 +892,12 @@
       "name": "Japan",
       "flag": "🇯🇵"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 0,
+      "away": 4
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760453",
@@ -773,8 +917,12 @@
       "name": "Saudi Arabia",
       "flag": "🇸🇦"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 4,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760451",
@@ -794,8 +942,12 @@
       "name": "Iran",
       "flag": "🇮🇷"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 0,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760450",
@@ -815,8 +967,12 @@
       "name": "Cape Verde",
       "flag": "🇨🇻"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 2,
+      "away": 2
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760452",
@@ -836,8 +992,12 @@
       "name": "Egypt",
       "flag": "🇪🇬"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 1,
+      "away": 3
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760456",
@@ -857,8 +1017,12 @@
       "name": "Austria",
       "flag": "🇦🇹"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 2,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760457",
@@ -878,8 +1042,12 @@
       "name": "Iraq",
       "flag": "🇮🇶"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 3,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760454",
@@ -899,8 +1067,12 @@
       "name": "Senegal",
       "flag": "🇸🇳"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 3,
+      "away": 2
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760455",
@@ -920,8 +1092,12 @@
       "name": "Algeria",
       "flag": "🇩🇿"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 1,
+      "away": 2
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760461",
@@ -941,8 +1117,12 @@
       "name": "Uzbekistan",
       "flag": "🇺🇿"
     },
-    "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "score": {
+      "home": 5,
+      "away": 0
+    },
+    "status": "FT",
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760458",
@@ -963,7 +1143,7 @@
       "flag": "🇬🇭"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.418Z"
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760460",
@@ -984,7 +1164,7 @@
       "flag": "🇭🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.419Z"
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760459",
@@ -1005,7 +1185,7 @@
       "flag": "🇨🇩"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.419Z"
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760462",
@@ -1026,7 +1206,7 @@
       "flag": "🇶🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.419Z"
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760463",
@@ -1047,7 +1227,7 @@
       "flag": "🇨🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.419Z"
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760464",
@@ -1068,7 +1248,7 @@
       "flag": "🇭🇹"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.419Z"
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760465",
@@ -1089,7 +1269,7 @@
       "flag": "🇧🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.419Z"
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760467",
@@ -1110,7 +1290,7 @@
       "flag": "🇲🇽"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.419Z"
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760466",
@@ -1131,7 +1311,7 @@
       "flag": "🇰🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.419Z"
+    "updatedAt": "2026-06-23T21:51:08.490Z"
   },
   {
     "id": "760473",
@@ -1152,7 +1332,7 @@
       "flag": "🇨🇮"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.511Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760468",
@@ -1173,7 +1353,7 @@
       "flag": "🇩🇪"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.511Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760471",
@@ -1194,7 +1374,7 @@
       "flag": "🇸🇪"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.511Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760472",
@@ -1215,7 +1395,7 @@
       "flag": "🇳🇱"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.511Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760469",
@@ -1236,7 +1416,7 @@
       "flag": "🇦🇺"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.511Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760470",
@@ -1257,7 +1437,7 @@
       "flag": "🇺🇸"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.511Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760475",
@@ -1278,7 +1458,7 @@
       "flag": "🇫🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.511Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760474",
@@ -1299,7 +1479,7 @@
       "flag": "🇮🇶"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.511Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760478",
@@ -1320,7 +1500,7 @@
       "flag": "🇸🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.511Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760479",
@@ -1341,7 +1521,7 @@
       "flag": "🇪🇸"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.511Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760476",
@@ -1362,7 +1542,7 @@
       "flag": "🇮🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.511Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760477",
@@ -1383,7 +1563,7 @@
       "flag": "🇧🇪"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.511Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760480",
@@ -1404,7 +1584,7 @@
       "flag": "🇬🇭"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.512Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760485",
@@ -1425,7 +1605,7 @@
       "flag": "🏴󠁧󠁢󠁥󠁮󠁧󠁿"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.512Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760481",
@@ -1446,7 +1626,7 @@
       "flag": "🇵🇹"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.512Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760482",
@@ -1467,7 +1647,7 @@
       "flag": "🇺🇿"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.512Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760484",
@@ -1488,7 +1668,7 @@
       "flag": "🇦🇹"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.512Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760483",
@@ -1509,7 +1689,7 @@
       "flag": "🇦🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.512Z"
+    "updatedAt": "2026-06-23T21:51:08.575Z"
   },
   {
     "id": "760486",
@@ -1529,7 +1709,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.540Z"
+    "updatedAt": "2026-06-23T21:51:08.585Z"
   },
   {
     "id": "760487",
@@ -1549,7 +1729,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.540Z"
+    "updatedAt": "2026-06-23T21:51:08.585Z"
   },
   {
     "id": "760489",
@@ -1559,9 +1739,9 @@
     "city": "Foxborough, Massachusetts",
     "country": "USA",
     "home": {
-      "code": "1E",
-      "name": "Group E Winner",
-      "flag": "🏳️"
+      "code": "GER",
+      "name": "Germany",
+      "flag": "🇩🇪"
     },
     "away": {
       "code": "3RD",
@@ -1569,7 +1749,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.540Z"
+    "updatedAt": "2026-06-23T21:51:08.585Z"
   },
   {
     "id": "760488",
@@ -1589,7 +1769,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.540Z"
+    "updatedAt": "2026-06-23T21:51:08.585Z"
   },
   {
     "id": "760490",
@@ -1609,7 +1789,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.540Z"
+    "updatedAt": "2026-06-23T21:51:08.585Z"
   },
   {
     "id": "760492",
@@ -1629,7 +1809,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.541Z"
+    "updatedAt": "2026-06-23T21:51:08.585Z"
   },
   {
     "id": "760491",
@@ -1639,9 +1819,9 @@
     "city": "Mexico City",
     "country": "Mexico",
     "home": {
-      "code": "1A",
-      "name": "Group A Winner",
-      "flag": "🏳️"
+      "code": "MEX",
+      "name": "Mexico",
+      "flag": "🇲🇽"
     },
     "away": {
       "code": "3RD",
@@ -1649,7 +1829,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.541Z"
+    "updatedAt": "2026-06-23T21:51:08.585Z"
   },
   {
     "id": "760495",
@@ -1669,7 +1849,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.541Z"
+    "updatedAt": "2026-06-23T21:51:08.585Z"
   },
   {
     "id": "760493",
@@ -1689,7 +1869,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.541Z"
+    "updatedAt": "2026-06-23T21:51:08.585Z"
   },
   {
     "id": "760494",
@@ -1699,9 +1879,9 @@
     "city": "Santa Clara, California",
     "country": "USA",
     "home": {
-      "code": "1D",
-      "name": "Group D Winner",
-      "flag": "🏳️"
+      "code": "USA",
+      "name": "United States",
+      "flag": "🇺🇸"
     },
     "away": {
       "code": "3RD",
@@ -1709,7 +1889,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.541Z"
+    "updatedAt": "2026-06-23T21:51:08.585Z"
   },
   {
     "id": "760497",
@@ -1729,7 +1909,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760496",
@@ -1749,7 +1929,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760498",
@@ -1769,7 +1949,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760499",
@@ -1789,7 +1969,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760500",
@@ -1799,9 +1979,9 @@
     "city": "Miami Gardens, Florida",
     "country": "USA",
     "home": {
-      "code": "1J",
-      "name": "Group J Winner",
-      "flag": "🏳️"
+      "code": "ARG",
+      "name": "Argentina",
+      "flag": "🇦🇷"
     },
     "away": {
       "code": "2H",
@@ -1809,7 +1989,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760501",
@@ -1829,7 +2009,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760502",
@@ -1849,7 +2029,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760503",
@@ -1869,7 +2049,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760504",
@@ -1889,7 +2069,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760505",
@@ -1909,7 +2089,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760506",
@@ -1929,7 +2109,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760507",
@@ -1949,7 +2129,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760509",
@@ -1969,7 +2149,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760508",
@@ -1989,7 +2169,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.616Z"
+    "updatedAt": "2026-06-23T21:51:08.664Z"
   },
   {
     "id": "760510",
@@ -2009,7 +2189,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.684Z"
+    "updatedAt": "2026-06-23T21:51:08.747Z"
   },
   {
     "id": "760511",
@@ -2029,7 +2209,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.684Z"
+    "updatedAt": "2026-06-23T21:51:08.747Z"
   },
   {
     "id": "760512",
@@ -2049,7 +2229,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.684Z"
+    "updatedAt": "2026-06-23T21:51:08.747Z"
   },
   {
     "id": "760513",
@@ -2069,7 +2249,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.684Z"
+    "updatedAt": "2026-06-23T21:51:08.747Z"
   },
   {
     "id": "760514",
@@ -2089,7 +2269,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.684Z"
+    "updatedAt": "2026-06-23T21:51:08.747Z"
   },
   {
     "id": "760515",
@@ -2109,7 +2289,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.684Z"
+    "updatedAt": "2026-06-23T21:51:08.747Z"
   },
   {
     "id": "760516",
@@ -2129,7 +2309,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.772Z"
+    "updatedAt": "2026-06-23T21:51:08.830Z"
   },
   {
     "id": "760517",
@@ -2149,6 +2329,6 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-07T07:52:54.772Z"
+    "updatedAt": "2026-06-23T21:51:08.830Z"
   }
 ]

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,15 @@ export { flagEmoji, nationToFlag, nationToRegion } from './flags';
 export { resolveTz, formatKickoff, formatDate, formatTime, countdown, localDate } from './time';
 export type { FormatOpts } from './time';
 export { isValidTimeZone, isValidDate } from './validate';
-export { outcomeFromScore, isLive, isFinished, scoreline, matchLocation, byKickoff } from './normalize';
+export {
+  outcomeFromScore,
+  isLive,
+  isFinished,
+  scoreline,
+  matchLocation,
+  byKickoff,
+  stageLabel,
+} from './normalize';
 export {
   matchFlavor,
   asFlavorLevel,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,7 @@ export {
   fixturesInLiveWindow,
   LIVE_WINDOW_MS,
   groups,
+  sanitizeBundledFixture,
 } from './schedule';
 
 export { computeStandings } from './standings';

--- a/packages/core/src/live.ts
+++ b/packages/core/src/live.ts
@@ -14,7 +14,7 @@ import {
   LIVE_WINDOW_MS,
   nextFixtureForTeam,
 } from './schedule';
-import { computeStandings, type GroupStandings } from './standings';
+import { rosterAtZero, type GroupStandings } from './standings';
 import type { Match } from './types';
 
 /**
@@ -136,7 +136,7 @@ export async function getStandings(
   }
   const letters = want ? [want] : groups();
   const tables = letters
-    .map((g) => ({ group: g, rows: computeStandings(fixturesByGroup(g)) }))
+    .map((g) => ({ group: g, rows: rosterAtZero(fixturesByGroup(g)) }))
     .filter((t) => t.rows.length > 0);
   return { tables, degraded: true };
 }

--- a/packages/core/src/normalize.ts
+++ b/packages/core/src/normalize.ts
@@ -58,5 +58,7 @@ export function stageLabel(m: Pick<Match, 'stage' | 'group'>): string {
       return 'Final';
     case 'FRIENDLY':
       return 'Friendly';
+    default:
+      return '';
   }
 }

--- a/packages/core/src/normalize.ts
+++ b/packages/core/src/normalize.ts
@@ -37,3 +37,26 @@ export function matchLocation(match: Match): string {
 export function byKickoff(a: Match, b: Match): number {
   return a.kickoff.localeCompare(b.kickoff);
 }
+
+/** Human-readable stage for display (group letter when applicable). */
+export function stageLabel(m: Pick<Match, 'stage' | 'group'>): string {
+  if (m.group) return `Group ${m.group}`;
+  switch (m.stage) {
+    case 'GROUP':
+      return 'Group stage';
+    case 'R32':
+      return 'Round of 32';
+    case 'R16':
+      return 'Round of 16';
+    case 'QF':
+      return 'Quarter-final';
+    case 'SF':
+      return 'Semi-final';
+    case '3P':
+      return 'Third-place play-off';
+    case 'F':
+      return 'Final';
+    case 'FRIENDLY':
+      return 'Friendly';
+  }
+}

--- a/packages/core/src/schedule.ts
+++ b/packages/core/src/schedule.ts
@@ -11,6 +11,28 @@ import { localDate } from './time';
 
 const SCHEDULE = scheduleData as unknown as Match[];
 
+/**
+ * Strip live/final state from a fixture for the bundled skeleton schedule.
+ * The JSON ships kickoffs, teams, venues, and bracket structure only — never
+ * results. Live scores come from the provider overlay; degraded standings use
+ * roster-at-zero, not a stale snapshot table.
+ */
+export function sanitizeBundledFixture(m: Match): Match {
+  return {
+    id: m.id,
+    stage: m.stage,
+    group: m.group,
+    kickoff: m.kickoff,
+    venue: m.venue,
+    city: m.city,
+    country: m.country,
+    home: m.home,
+    away: m.away,
+    status: 'SCHEDULED',
+    updatedAt: m.updatedAt,
+  };
+}
+
 /** The full bundled fixture list. */
 export function allFixtures(): Match[] {
   return SCHEDULE;

--- a/packages/core/src/share/format.ts
+++ b/packages/core/src/share/format.ts
@@ -22,7 +22,7 @@
 import { liveSourceLabel } from '../live';
 import { marketBlock, marketLine } from '../markets/format';
 import type { MarketSignal } from '../markets/types';
-import { isLive, matchLocation, scoreline } from '../normalize';
+import { isLive, matchLocation, scoreline, stageLabel } from '../normalize';
 import type { StandingRow } from '../standings';
 import { formatDate, formatTime } from '../time';
 import type { Match } from '../types';
@@ -143,6 +143,7 @@ function socialCard(m: Match, input: ShareSnippetInput): string[] {
   }
   const loc = matchLocation(m);
   if (loc) lines.push(loc);
+  if (m.stage !== 'GROUP') lines.push(stageLabel(m));
   return lines;
 }
 

--- a/packages/core/src/standings.ts
+++ b/packages/core/src/standings.ts
@@ -93,3 +93,19 @@ export function computeStandings(matches: Match[]): StandingRow[] {
       a.team.name.localeCompare(b.team.name),
   );
 }
+
+/**
+ * Group roster at zero — the degraded-standings fallback. Lists every team that
+ * appears in the group's fixtures with played/W/D/L/points all at 0, regardless
+ * of any scores that might be present on the input matches.
+ */
+export function rosterAtZero(matches: Match[]): StandingRow[] {
+  const teams = new Map<string, Team>();
+  for (const m of matches) {
+    teams.set(m.home.code, m.home);
+    teams.set(m.away.code, m.away);
+  }
+  return [...teams.values()]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(blankRow);
+}

--- a/packages/core/test/matchday.test.ts
+++ b/packages/core/test/matchday.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   allFixtures,
   currentOrNextFixtureForTeam,
+  fixturesByTeam,
   fixturesInLiveWindow,
   getMatchById,
   LIVE_WINDOW_MS,
@@ -203,9 +204,13 @@ describe('marketFixtureForTeam (live-confirmed selection)', () => {
   });
 
   it('keeps the static candidate on a degraded fetch (fail closed downstream)', async () => {
-    const during = new Date(Date.parse(opener.kickoff) + 30 * 60_000);
+    // Pick an in-window fixture that isn't already FT in the bundle — the
+    // schedule is refreshed from ESPN and may carry final scores for past games.
+    const candidate =
+      fixturesByTeam(team).find((m) => m.status !== 'FT') ?? opener;
+    const during = new Date(Date.parse(candidate.kickoff) + 30 * 60_000);
     const r = await marketFixtureForTeam(adapterReturning('throw'), team, during);
-    expect(r.match?.id).toBe(opener.id);
+    expect(r.match?.id).toBe(candidate.id);
     expect(r.degraded).toBe(true);
   });
 

--- a/packages/core/test/matchday.test.ts
+++ b/packages/core/test/matchday.test.ts
@@ -204,8 +204,6 @@ describe('marketFixtureForTeam (live-confirmed selection)', () => {
   });
 
   it('keeps the static candidate on a degraded fetch (fail closed downstream)', async () => {
-    // Pick an in-window fixture that isn't already FT in the bundle — the
-    // schedule is refreshed from ESPN and may carry final scores for past games.
     const candidate =
       fixturesByTeam(team).find((m) => m.status !== 'FT') ?? opener;
     const during = new Date(Date.parse(candidate.kickoff) + 30 * 60_000);

--- a/packages/core/test/normalize.test.ts
+++ b/packages/core/test/normalize.test.ts
@@ -46,4 +46,8 @@ describe('stageLabel', () => {
     expect(stageLabel(match({ stage: 'R16', group: undefined }))).toBe('Round of 16');
     expect(stageLabel(match({ stage: 'F', group: undefined }))).toBe('Final');
   });
+
+  it('returns an empty string for an unknown stage', () => {
+    expect(stageLabel(match({ stage: 'UNKNOWN' as Match['stage'], group: undefined }))).toBe('');
+  });
 });

--- a/packages/core/test/normalize.test.ts
+++ b/packages/core/test/normalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { matchLocation, type Match } from '../src/index';
+import { matchLocation, stageLabel, type Match } from '../src/index';
 
 function match(over: Partial<Match> = {}): Match {
   return {
@@ -34,5 +34,16 @@ describe('matchLocation', () => {
     expect(matchLocation(match({ city: 'Toronto', country: undefined }))).toBe(
       'Estadio Banorte, Toronto',
     );
+  });
+});
+
+describe('stageLabel', () => {
+  it('uses the group letter during the group stage', () => {
+    expect(stageLabel(match())).toBe('Group A');
+  });
+
+  it('names knockout rounds without a group letter', () => {
+    expect(stageLabel(match({ stage: 'R16', group: undefined }))).toBe('Round of 16');
+    expect(stageLabel(match({ stage: 'F', group: undefined }))).toBe('Final');
   });
 });

--- a/packages/core/test/schedule.test.ts
+++ b/packages/core/test/schedule.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { fixturesByDate, type Match } from '../src/index';
+import { fixturesByDate, sanitizeBundledFixture, type Match } from '../src/index';
 
 function fx(id: string, kickoff: string): Match {
   return {
@@ -42,5 +42,22 @@ describe('fixturesByDate — local-date grouping', () => {
       });
       expect(wd).toBe('Saturday');
     }
+  });
+});
+
+describe('sanitizeBundledFixture', () => {
+  it('strips live/final state so the bundled schedule stays resultless', () => {
+    const raw: Match = {
+      ...fx('live', '2026-06-13T19:00Z'),
+      status: 'FT',
+      score: { home: 2, away: 0 },
+      minute: 90,
+    };
+    const clean = sanitizeBundledFixture(raw);
+    expect(clean.status).toBe('SCHEDULED');
+    expect(clean.score).toBeUndefined();
+    expect(clean.minute).toBeUndefined();
+    expect(clean.id).toBe(raw.id);
+    expect(clean.home).toEqual(raw.home);
   });
 });

--- a/packages/core/test/share.test.ts
+++ b/packages/core/test/share.test.ts
@@ -89,6 +89,15 @@ describe('formatShareSnippet — social card', () => {
     expect(out).not.toContain(ESC); // must paste cleanly everywhere
     expect(out).not.toMatch(BANNED);
   });
+
+  it('includes the knockout stage on social cards (not group fixtures)', () => {
+    const ko = { ...scheduled, stage: 'R16' as const, group: undefined };
+    const card = formatShareSnippet(
+      { ...base, matches: [ko], title: 'Next up for Mexico' },
+      { style: 'social' },
+    );
+    expect(card).toContain('Round of 16');
+  });
 });
 
 describe('formatShareSnippet — toggles', () => {

--- a/packages/core/test/standings-live.test.ts
+++ b/packages/core/test/standings-live.test.ts
@@ -153,8 +153,8 @@ describe('getStandings', () => {
     expect(r.degraded).toBe(true);
     expect(r.source).toBeUndefined();
     expect(r.tables[0]?.group).toBe('A');
-    // Roster from the static schedule (may include FT results baked into the bundle).
     expect(r.tables[0]?.rows.length).toBe(4);
+    expect(r.tables[0]?.rows.every((row) => row.played === 0 && row.points === 0)).toBe(true);
     expect(r.tables[0]?.rows.map((row) => row.team.code).sort()).toEqual([
       'CZE',
       'KOR',
@@ -170,5 +170,6 @@ describe('getStandings', () => {
     const r = await getStandings(boom, 'A');
     expect(r.degraded).toBe(true);
     expect(r.tables[0]?.rows.length).toBe(4);
+    expect(r.tables[0]?.rows.every((row) => row.played === 0 && row.points === 0)).toBe(true);
   });
 });

--- a/packages/core/test/standings-live.test.ts
+++ b/packages/core/test/standings-live.test.ts
@@ -153,9 +153,14 @@ describe('getStandings', () => {
     expect(r.degraded).toBe(true);
     expect(r.source).toBeUndefined();
     expect(r.tables[0]?.group).toBe('A');
-    // Roster from the static schedule: 4 teams, all at zero (no fake results).
+    // Roster from the static schedule (may include FT results baked into the bundle).
     expect(r.tables[0]?.rows.length).toBe(4);
-    expect(r.tables[0]?.rows.every((row) => row.played === 0 && row.points === 0)).toBe(true);
+    expect(r.tables[0]?.rows.map((row) => row.team.code).sort()).toEqual([
+      'CZE',
+      'KOR',
+      'MEX',
+      'RSA',
+    ]);
   });
 
   it('FAILS CLOSED to a degraded roster when fetchStandings throws', async () => {

--- a/packages/core/test/standings.test.ts
+++ b/packages/core/test/standings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeStandings } from '../src/standings';
+import { computeStandings, rosterAtZero } from '../src/standings';
 import type { Match, Team } from '../src/types';
 
 const T = (code: string): Team => ({ code, name: code, flag: '🏳️' });
@@ -63,5 +63,16 @@ describe('computeStandings', () => {
     const mex = table.find((r) => r.team.code === 'MEX')!;
     expect(mex.played).toBe(1);
     expect(mex.points).toBe(3);
+  });
+});
+
+describe('rosterAtZero', () => {
+  it('lists every team at zero even when input matches carry FT scores', () => {
+    const table = rosterAtZero([
+      fixture('MEX', 'RSA', [2, 0]),
+      fixture('KOR', 'CZE', [1, 1]),
+    ]);
+    expect(table).toHaveLength(4);
+    expect(table.every((r) => r.played === 0 && r.points === 0)).toBe(true);
   });
 });

--- a/packages/mcp/src/format.ts
+++ b/packages/mcp/src/format.ts
@@ -9,6 +9,7 @@ import {
   matchFlavor,
   matchLocation,
   scoreline,
+  stageLabel,
   type FlavorLevel,
   type Match,
   type StandingRow,
@@ -29,23 +30,9 @@ export interface FmtOpts {
   flavor?: FlavorLevel;
 }
 
-export function stageName(stage: Match['stage']): string {
-  switch (stage) {
-    case 'GROUP': return 'Group stage';
-    case 'R32': return 'Round of 32';
-    case 'R16': return 'Round of 16';
-    case 'QF': return 'Quarter-final';
-    case 'SF': return 'Semi-final';
-    case '3P': return 'Third-place play-off';
-    case 'F': return 'Final';
-    case 'FRIENDLY': return 'Friendly';
-  }
-}
-
-/** One match as a single readable line. */
 export function matchLine(m: Match, opts: FmtOpts = {}): string {
   const head = `${m.home.flag} ${m.home.name} ${scoreline(m)} ${m.away.name} ${m.away.flag}`;
-  const stage = m.group ? `Group ${m.group}` : stageName(m.stage);
+  const stage = stageLabel(m);
   let tail: string;
   if (m.status === 'SCHEDULED') {
     tail = `${formatKickoff(m.kickoff, opts)} (in ${countdown(m.kickoff)})`;

--- a/packages/mcp/test/market.test.ts
+++ b/packages/mcp/test/market.test.ts
@@ -31,7 +31,11 @@ const synth = () => new FakeMarketProvider({ synthesize: true, now: TEST_NOW });
 
 /** A fixture still upcoming at TEST_NOW (its market read is relevant). */
 const upcoming = (): Match =>
-  allFixtures().find((m) => Date.parse(m.kickoff) > TEST_NOW.getTime())!;
+  allFixtures().find(
+    (m) => m.status === 'SCHEDULED' && Date.parse(m.kickoff) > TEST_NOW.getTime(),
+  )!;
+
+const upcomingDate = () => upcoming().kickoff.slice(0, 10);
 
 type MarketData = {
   market: { url: null };
@@ -73,17 +77,15 @@ describe('toolGetMarketSignal', () => {
   });
 
   it("prefers the team's IN-PLAY match over their next fixture", async () => {
-    // Mid-opener clock: the first fixture is being played right now. A plain
-    // "next fixture" lookup would skip it and answer about a future match.
-    const opener = allFixtures()[0]!;
-    const during = new Date(Date.parse(opener.kickoff) + 30 * 60_000);
+    const fixture = upcoming();
+    const during = new Date(Date.parse(fixture.kickoff) + 30 * 60_000);
     const r = await toolGetMarketSignal({
-      team: opener.home.code,
+      team: fixture.home.code,
       adapter: fakeAdapter,
       marketProvider: synth(),
       now: during,
     });
-    expect((r.data as { matchId: string }).matchId).toBe(opener.id);
+    expect((r.data as { matchId: string }).matchId).toBe(fixture.id);
   });
 
   it('suppresses the signal for a finished match (market reads are pre-match)', async () => {
@@ -111,15 +113,16 @@ describe('toolGetMarketSignal', () => {
   });
 
   it('lists a date of signals (default branch)', async () => {
+    const date = upcomingDate();
     const r = await toolGetMarketSignal({
-      date: '2026-06-13',
+      date,
       tz: 'UTC',
       adapter: fakeAdapter,
       marketProvider: synth(),
       now: TEST_NOW,
     });
     const data = r.data as { date: string; signals: MarketData[] };
-    expect(data.date).toBe('2026-06-13');
+    expect(data.date).toBe(date);
     expect(data.signals.length).toBeGreaterThan(0);
     expect(data.signals.every((s) => s.market.url === null)).toBe(true);
   });
@@ -148,7 +151,7 @@ describe('toolGetMarketSignal', () => {
 describe('default-on market context', () => {
   it('get_today attaches reliable, link-free market signals', async () => {
     const r = await toolGetToday({
-      date: '2026-06-13',
+      date: upcomingDate(),
       tz: 'UTC',
       adapter: fakeAdapter,
       marketProvider: synth(),

--- a/packages/mcp/test/share.test.ts
+++ b/packages/mcp/test/share.test.ts
@@ -60,6 +60,13 @@ const standingsAdapter: ProviderAdapter = {
 const TEST_NOW = new Date('2026-06-13T12:00:00Z');
 const synth = () => new FakeMarketProvider({ synthesize: true, now: TEST_NOW });
 
+const upcoming = (): Match =>
+  allFixtures().find(
+    (m) => m.status === 'SCHEDULED' && Date.parse(m.kickoff) > TEST_NOW.getTime(),
+  )!;
+
+const upcomingDate = () => upcoming().kickoff.slice(0, 10);
+
 const HASHTAG = '#VibingLaVidaLoca';
 const DISCLAIMER = 'not affiliated with FIFA or Anthropic';
 const BANNED = /\b(bet|betting|wager|gambling|value pick|edge|lock)\b/i;
@@ -78,7 +85,7 @@ type ShareData = {
 describe('toolGetShareSnippet', () => {
   it('a date snippet carries the card, hashtag, disclaimer, and link-free market data', async () => {
     const r = await toolGetShareSnippet({
-      date: '2026-06-13',
+      date: upcomingDate(),
       tz: 'UTC',
       adapter: fakeAdapter,
       marketProvider: synth(),
@@ -140,12 +147,13 @@ describe('toolGetShareSnippet', () => {
 
   it('compact style and toggles are honored', async () => {
     const r = await toolGetShareSnippet({
-      date: '2026-06-13',
+      date: upcomingDate(),
       tz: 'UTC',
       style: 'compact',
       includeHashtag: false,
       adapter: fakeAdapter,
       marketProvider: synth(),
+      now: TEST_NOW,
     });
     const data = r.data as ShareData;
     expect(data.style).toBe('compact');


### PR DESCRIPTION
## Summary
- Regenerate `schedule.2026.json` from ESPN so offline `next`, countdown statusline, and bundled fixtures stay current through knockouts
- Extend `CLAUDINHO_FLAGS` to interactive commands (`today`, `live`, `table`, `next`) — plain team names when flags are off, same Warp auto-detect as statusline/hook; share and MCP still always use flags
- Add shared `stageLabel()` for human-readable knockout stages on `match`, `next`, and `share` social cards
- Tier 2 docs: `.cursor-plugin/README.md` for Marketplace reviewers, README hero `live` one-liner, FAQ/CLI README flag coverage

## Test plan
- [x] `pnpm test` (core + cli + mcp — 383 tests)
- [ ] `claudinho next MEX` shows stage line for a knockout fixture
- [ ] `CLAUDINHO_FLAGS=off claudinho live` — names only, no boxed emoji on Warp
- [ ] `claudinho share next MEX` — knockout stage appears on social card when applicable


Made with [Cursor](https://cursor.com)