### PR TITLE
fix(core): bracket flags + compact share wiring

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -1095,6 +1095,8 @@ export async function cmdShare(
           includeHashtag: baseOptions.includeHashtag,
           includeInstallLine: baseOptions.includeInstallLine,
           locale: cfg.lang,
+          style: baseOptions.style,
+          tz: cfg.tz,
         },
       },
       copy,

--- a/packages/core/src/bracket/format.ts
+++ b/packages/core/src/bracket/format.ts
@@ -155,7 +155,7 @@ export function formatShareBracket(
       blocks.push(`(${t(locale, 'bracket.standingsDegraded')})`);
     }
   } else {
-    blocks.push(formatBracketList(input.view, { footer: false, locale }));
+    blocks.push(formatBracketList(input.view, { footer: false, locale, tz: options.tz }));
     if (input.view.degraded) {
       blocks.push(`(${t(locale, 'bracket.degraded')})`);
     } else if (input.view.standingsDegraded) {

--- a/packages/core/src/bracket/format.ts
+++ b/packages/core/src/bracket/format.ts
@@ -1,7 +1,7 @@
 import { isFinished, isLive, scoreline } from '../normalize';
 import { t, stageLabelI18n } from '../i18n';
 import { formatKickoff, formatTime } from '../time';
-import { SHARE_DISCLAIMER, SHARE_HASHTAG } from '../share/format';
+import { SHARE_DISCLAIMER, SHARE_HASHTAG, type ShareStyle } from '../share/format';
 import { liveSourceLabel } from '../live';
 import type { Stage } from '../types';
 import type { BracketMatchView, BracketView, ResolvedParticipant } from './types';
@@ -127,6 +127,8 @@ export interface ShareBracketOptions {
   includeInstallLine?: boolean;
   stage?: Stage;
   locale?: string;
+  tz?: string;
+  style?: ShareStyle;
 }
 
 /** Plain-text share card for the knockout bracket. */
@@ -141,6 +143,17 @@ export function formatShareBracket(
 
   if (input.view.stages.length === 0) {
     blocks.push(input.emptyNote ?? t(locale, 'bracket.empty'));
+  } else if ((options.style ?? 'social') === 'compact') {
+    const fmtOpts = { locale, tz: options.tz };
+    const lines = input.view.stages.flatMap((stage) =>
+      stage.matches.map((mv) => formatBracketCompactLine(mv, fmtOpts)),
+    );
+    blocks.push(lines.join('\n'));
+    if (input.view.degraded) {
+      blocks.push(`(${t(locale, 'bracket.degraded')})`);
+    } else if (input.view.standingsDegraded) {
+      blocks.push(`(${t(locale, 'bracket.standingsDegraded')})`);
+    }
   } else {
     blocks.push(formatBracketList(input.view, { footer: false, locale }));
     if (input.view.degraded) {

--- a/packages/core/src/bracket/format.ts
+++ b/packages/core/src/bracket/format.ts
@@ -12,11 +12,19 @@ export interface BracketFormatOpts {
   locale?: string;
 }
 
-function formatParticipant(p: ResolvedParticipant, flags: boolean, locale?: string): string {
+function formatParticipant(
+  p: ResolvedParticipant,
+  side: 'home' | 'away',
+  flags: boolean,
+  locale?: string,
+): string {
   const suffix = p.status === 'projected' ? ` ${t(locale, 'bracket.projected')}` : '';
-  if (flags && p.flag !== '🏳️') return `${p.flag} ${p.label}${suffix}`;
-  if (p.code) return `${p.code}${suffix}`;
-  return `${p.label}${suffix}`;
+  if (!flags || p.flag === '🏳️') {
+    if (p.code && p.code !== 'TBD') return `${p.code}${suffix}`;
+    return `${p.label}${suffix}`;
+  }
+  if (side === 'home') return `${p.flag} ${p.label}${suffix}`;
+  return `${p.label}${suffix} ${p.flag}`;
 }
 
 function statusTail(m: BracketMatchView['match']): string {
@@ -30,8 +38,8 @@ function statusTail(m: BracketMatchView['match']): string {
 /** One bracket match line for list or tree output. */
 export function formatBracketMatchLine(mv: BracketMatchView, opts: BracketFormatOpts = {}): string {
   const flags = opts.flags !== false;
-  const home = formatParticipant(mv.home, flags, opts.locale);
-  const away = formatParticipant(mv.away, flags, opts.locale);
+  const home = formatParticipant(mv.home, 'home', flags, opts.locale);
+  const away = formatParticipant(mv.away, 'away', flags, opts.locale);
   const m = mv.match;
   if (isFinished(m.status) || isLive(m.status)) {
     return `  ${home}  ${scoreline(m)}  ${away}${statusTail(m)}`;
@@ -158,8 +166,8 @@ export function formatShareBracket(
 /** Compact one-line-per-match bracket for narrow share contexts. */
 export function formatBracketCompactLine(mv: BracketMatchView, opts: BracketFormatOpts = {}): string {
   const flags = opts.flags !== false;
-  const home = flags && mv.home.code ? `${mv.home.flag} ${mv.home.code}` : mv.home.label;
-  const away = flags && mv.away.code ? `${mv.away.code} ${mv.away.flag}` : mv.away.label;
+  const home = formatParticipant(mv.home, 'home', flags, opts.locale);
+  const away = formatParticipant(mv.away, 'away', flags, opts.locale);
   const m = mv.match;
   const mid = isFinished(m.status) || isLive(m.status) ? scoreline(m) : 'vs';
   const tail = m.status === 'SCHEDULED' && mv.kickoff

--- a/packages/core/src/bracket/format.ts
+++ b/packages/core/src/bracket/format.ts
@@ -1,6 +1,6 @@
 import { isFinished, isLive, scoreline } from '../normalize';
 import { t, stageLabelI18n } from '../i18n';
-import { formatKickoff, formatTime } from '../time';
+import { formatKickoff } from '../time';
 import { SHARE_DISCLAIMER, SHARE_HASHTAG, type ShareStyle } from '../share/format';
 import { liveSourceLabel } from '../live';
 import type { Stage } from '../types';
@@ -184,7 +184,7 @@ export function formatBracketCompactLine(mv: BracketMatchView, opts: BracketForm
   const m = mv.match;
   const mid = isFinished(m.status) || isLive(m.status) ? scoreline(m) : 'vs';
   const tail = m.status === 'SCHEDULED' && mv.kickoff
-    ? ` · ${formatTime(mv.kickoff, { tz: opts.tz, locale: opts.locale })}`
+    ? ` · ${formatKickoff(mv.kickoff, { tz: opts.tz, locale: opts.locale })}`
     : statusTail(m);
   return `${stageLabelI18n(opts.locale, mv.stage)} · ${home} ${mid} ${away}${tail}`;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -126,6 +126,7 @@ export {
   formatBracketList,
   formatBracketTree,
   formatBracketMatchLine,
+  formatBracketCompactLine,
   formatShareBracket,
 } from './bracket/format';
 export type {

--- a/packages/core/test/bracket-format.test.ts
+++ b/packages/core/test/bracket-format.test.ts
@@ -33,6 +33,15 @@ describe('formatBracketMatchLine', () => {
     expect(line).not.toMatch(/🇲🇽 Mexico/);
   });
 
+  it('formatShareBracket social style honors tz for kickoff times', () => {
+    const stages = [{ stage: 'R32' as const, label: 'Round of 32', matches: [view] }];
+    const card = formatShareBracket(
+      { view: { stages, degraded: true, standingsDegraded: false } },
+      { locale: 'en', tz: 'UTC' },
+    );
+    expect(card).toContain('Sat 17:00');
+  });
+
   it('formatShareBracket compact style uses one line per match with kickoff day', () => {
     const stages = [{ stage: 'R32' as const, label: 'Round of 32', matches: [view] }];
     const card = formatShareBracket(

--- a/packages/core/test/bracket-format.test.ts
+++ b/packages/core/test/bracket-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatBracketMatchLine } from '../src/bracket/format';
+import { formatBracketMatchLine, formatShareBracket } from '../src/bracket/format';
 import type { BracketMatchView } from '../src/bracket/types';
 import type { Match } from '../src/types';
 
@@ -31,5 +31,15 @@ describe('formatBracketMatchLine', () => {
     expect(line).toContain('Mexico 🇲🇽');
     expect(line).not.toMatch(/Czechia 🇨🇿/);
     expect(line).not.toMatch(/🇲🇽 Mexico/);
+  });
+
+  it('formatShareBracket compact style uses one line per match', () => {
+    const stages = [{ stage: 'R32' as const, label: 'Round of 32', matches: [view] }];
+    const card = formatShareBracket(
+      { view: { stages, degraded: true, standingsDegraded: false } },
+      { style: 'compact', locale: 'en' },
+    );
+    expect(card).toContain('Round of 32 · 🇨🇿 Czechia vs Mexico 🇲🇽');
+    expect(card.split('\n').filter((l) => l.includes('vs')).length).toBe(1);
   });
 });

--- a/packages/core/test/bracket-format.test.ts
+++ b/packages/core/test/bracket-format.test.ts
@@ -33,13 +33,14 @@ describe('formatBracketMatchLine', () => {
     expect(line).not.toMatch(/🇲🇽 Mexico/);
   });
 
-  it('formatShareBracket compact style uses one line per match', () => {
+  it('formatShareBracket compact style uses one line per match with kickoff day', () => {
     const stages = [{ stage: 'R32' as const, label: 'Round of 32', matches: [view] }];
     const card = formatShareBracket(
       { view: { stages, degraded: true, standingsDegraded: false } },
-      { style: 'compact', locale: 'en' },
+      { style: 'compact', locale: 'en', tz: 'UTC' },
     );
     expect(card).toContain('Round of 32 · 🇨🇿 Czechia vs Mexico 🇲🇽');
+    expect(card).toContain('Sat 17:00');
     expect(card.split('\n').filter((l) => l.includes('vs')).length).toBe(1);
   });
 });

--- a/packages/core/test/bracket-format.test.ts
+++ b/packages/core/test/bracket-format.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { formatBracketMatchLine } from '../src/bracket/format';
+import type { BracketMatchView } from '../src/bracket/types';
+import type { Match } from '../src/types';
+
+const match: Match = {
+  id: '1',
+  stage: 'R32',
+  kickoff: '2026-07-04T17:00Z',
+  venue: 'X',
+  home: { code: 'CZE', name: 'Czechia', flag: '🇨🇿' },
+  away: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+  status: 'SCHEDULED',
+  updatedAt: '',
+};
+
+const view: BracketMatchView = {
+  matchId: '1',
+  stage: 'R32',
+  index: 1,
+  kickoff: match.kickoff,
+  home: { label: 'Czechia', flag: '🇨🇿', code: 'CZE', status: 'confirmed' },
+  away: { label: 'Mexico', flag: '🇲🇽', code: 'MEX', status: 'confirmed' },
+  match,
+};
+
+describe('formatBracketMatchLine', () => {
+  it('mirrors next/matchLine flag placement (home before, away after)', () => {
+    const line = formatBracketMatchLine(view, { flags: true });
+    expect(line).toContain('🇨🇿 Czechia');
+    expect(line).toContain('Mexico 🇲🇽');
+    expect(line).not.toMatch(/Czechia 🇨🇿/);
+    expect(line).not.toMatch(/🇲🇽 Mexico/);
+  });
+});

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -652,7 +652,7 @@ export async function toolGetShareSnippet(args: ShareArgs): Promise<ToolResult> 
           : 'npx @claudinho/cli bracket',
         emptyNote: t(args.lang, 'bracket.empty'),
       },
-      { ...options, locale: args.lang },
+      { ...options, locale: args.lang, tz: args.tz },
     );
     return {
       text: snippet,


### PR DESCRIPTION
## Summary
- Mirror `next` / `matchLine` flag layout in bracket output: home flag before name, away flag after name
- Wire `formatBracketCompactLine` for `share bracket --style compact` and MCP `get_share_snippet(bracket, style: compact)`; export from `@claudinho/core`
- Compact share rows include kickoff day abbrev (`Sat 17:00`) — bracket spans Jun 28→Jul 19

## Test plan
- [x] `pnpm -r build && pnpm -r typecheck && pnpm -r test && pnpm lint` all green locally
- [x] `bracket-format.test.ts` — flag order + compact share with day abbrev
- [ ] `claudinho bracket` visually matches `claudinho next` flag placement