### PR TITLE
fix(core): host R32 paths resolve via group-winner slots

### DIFF
--- a/packages/core/src/bracket/parse.ts
+++ b/packages/core/src/bracket/parse.ts
@@ -1,6 +1,6 @@
 import type { Team } from '../types';
 import type { SlotRef } from './types';
-import { isResolvedNation } from './placeholders';
+import { isResolvedNation, NATION_AS_GROUP_WINNER } from './placeholders';
 
 const PLACEHOLDER_FLAG = '🏳️';
 
@@ -37,6 +37,8 @@ export function parseTeamSlot(team: Team): SlotRef | null {
   if (m) return { kind: 'loser', stage: 'SF', index: Number(m[1]) };
 
   if (isResolvedNation(team)) {
+    const group = NATION_AS_GROUP_WINNER[team.name];
+    if (group) return { kind: 'group', position: 1, group };
     return { kind: 'seed', label: team.name, code: 'TBD' };
   }
 

--- a/packages/core/src/bracket/placeholders.ts
+++ b/packages/core/src/bracket/placeholders.ts
@@ -3,6 +3,18 @@ import type { SlotRef } from './types';
 
 const PLACEHOLDER_FLAG = '🏳️';
 
+/**
+ * ESPN labels some R32 slots with a nation name (pre-draw host/path assignment).
+ * Topology keys them as group-winner refs so they resolve from standings when the
+ * group finishes — not frozen seed labels.
+ */
+export const NATION_AS_GROUP_WINNER: Readonly<Record<string, string>> = {
+  Mexico: 'A',
+  Germany: 'E',
+  'United States': 'D',
+  Argentina: 'J',
+};
+
 function winnerName(stage: Stage, index: number): string {
   switch (stage) {
     case 'R32':

--- a/packages/core/src/bracket/resolve.ts
+++ b/packages/core/src/bracket/resolve.ts
@@ -1,4 +1,3 @@
-import { isResolvedNation } from './placeholders';
 import { t, stageLabelI18n } from '../i18n';
 import { isFinished, outcomeFromScore } from '../normalize';
 import type { GroupStandings } from '../standings';
@@ -84,20 +83,10 @@ function winnerLabel(ctx: ResolveContext, stage: string, index: number): string 
   });
 }
 
-function resolveSlot(
-  ref: SlotRef,
-  ctx: ResolveContext,
-  match: Match,
-  side: 'home' | 'away',
-): ResolvedParticipant {
+function resolveSlot(ref: SlotRef, ctx: ResolveContext): ResolvedParticipant {
   switch (ref.kind) {
-    case 'seed': {
-      const team = side === 'home' ? match.home : match.away;
-      if (team.name === ref.label && isResolvedNation(team)) {
-        return participant(team, 'confirmed');
-      }
+    case 'seed':
       return tbd(ref.label);
-    }
     case 'group': {
       if (isGroupComplete(ref.group, ctx.tables, ctx.standingsDegraded)) {
         const team = teamFromStandings(ref.group, ref.position, ctx.tables);
@@ -182,8 +171,8 @@ export function buildBracketView(
         stage: node.stage,
         index: node.index,
         kickoff: match.kickoff,
-        home: resolveSlot(node.home, ctx, match, 'home'),
-        away: resolveSlot(node.away, ctx, match, 'away'),
+        home: resolveSlot(node.home, ctx),
+        away: resolveSlot(node.away, ctx),
         match,
       };
     });

--- a/packages/core/src/bracket/resolve.ts
+++ b/packages/core/src/bracket/resolve.ts
@@ -1,3 +1,4 @@
+import { isResolvedNation } from './placeholders';
 import { t, stageLabelI18n } from '../i18n';
 import { isFinished, outcomeFromScore } from '../normalize';
 import type { GroupStandings } from '../standings';
@@ -83,10 +84,20 @@ function winnerLabel(ctx: ResolveContext, stage: string, index: number): string 
   });
 }
 
-function resolveSlot(ref: SlotRef, ctx: ResolveContext): ResolvedParticipant {
+function resolveSlot(
+  ref: SlotRef,
+  ctx: ResolveContext,
+  match: Match,
+  side: 'home' | 'away',
+): ResolvedParticipant {
   switch (ref.kind) {
-    case 'seed':
+    case 'seed': {
+      const team = side === 'home' ? match.home : match.away;
+      if (team.name === ref.label && isResolvedNation(team)) {
+        return participant(team, 'confirmed');
+      }
       return tbd(ref.label);
+    }
     case 'group': {
       if (isGroupComplete(ref.group, ctx.tables, ctx.standingsDegraded)) {
         const team = teamFromStandings(ref.group, ref.position, ctx.tables);
@@ -171,8 +182,8 @@ export function buildBracketView(
         stage: node.stage,
         index: node.index,
         kickoff: match.kickoff,
-        home: resolveSlot(node.home, ctx),
-        away: resolveSlot(node.away, ctx),
+        home: resolveSlot(node.home, ctx, match, 'home'),
+        away: resolveSlot(node.away, ctx, match, 'away'),
         match,
       };
     });

--- a/packages/core/src/data/bracket.2026.json
+++ b/packages/core/src/data/bracket.2026.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-24T01:20:06.749Z",
+  "generatedAt": "2026-06-24T03:57:24.994Z",
   "stages": [
     "R32",
     "R16",
@@ -59,9 +59,9 @@
       "stage": "R32",
       "index": 4,
       "home": {
-        "kind": "seed",
-        "label": "Germany",
-        "code": "TBD"
+        "kind": "group",
+        "position": 1,
+        "group": "E"
       },
       "away": {
         "kind": "third",
@@ -94,9 +94,9 @@
       "stage": "R32",
       "index": 6,
       "home": {
-        "kind": "seed",
-        "label": "Mexico",
-        "code": "TBD"
+        "kind": "group",
+        "position": 1,
+        "group": "A"
       },
       "away": {
         "kind": "third",
@@ -154,9 +154,9 @@
       "stage": "R32",
       "index": 9,
       "home": {
-        "kind": "seed",
-        "label": "United States",
-        "code": "TBD"
+        "kind": "group",
+        "position": 1,
+        "group": "D"
       },
       "away": {
         "kind": "third",
@@ -259,9 +259,9 @@
       "stage": "R32",
       "index": 15,
       "home": {
-        "kind": "seed",
-        "label": "Argentina",
-        "code": "TBD"
+        "kind": "group",
+        "position": 1,
+        "group": "J"
       },
       "away": {
         "kind": "group",

--- a/packages/core/src/data/schedule.2026.json
+++ b/packages/core/src/data/schedule.2026.json
@@ -18,7 +18,7 @@
       "flag": "🇿🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.301Z"
+    "updatedAt": "2026-06-24T03:57:24.568Z"
   },
   {
     "id": "760414",
@@ -39,7 +39,7 @@
       "flag": "🇨🇿"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760416",
@@ -60,7 +60,7 @@
       "flag": "🇧🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760417",
@@ -81,7 +81,7 @@
       "flag": "🇵🇾"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760420",
@@ -102,7 +102,7 @@
       "flag": "🇨🇭"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760419",
@@ -123,7 +123,7 @@
       "flag": "🇲🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760418",
@@ -144,7 +144,7 @@
       "flag": "🏴󠁧󠁢󠁳󠁣󠁴󠁿"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760421",
@@ -165,7 +165,7 @@
       "flag": "🇹🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760422",
@@ -186,7 +186,7 @@
       "flag": "🇨🇼"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760425",
@@ -207,7 +207,7 @@
       "flag": "🇯🇵"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760423",
@@ -228,7 +228,7 @@
       "flag": "🇪🇨"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760424",
@@ -249,7 +249,7 @@
       "flag": "🇹🇳"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760428",
@@ -270,7 +270,7 @@
       "flag": "🇨🇻"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760426",
@@ -291,7 +291,7 @@
       "flag": "🇪🇬"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760429",
@@ -312,7 +312,7 @@
       "flag": "🇺🇾"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760427",
@@ -333,7 +333,7 @@
       "flag": "🇳🇿"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760432",
@@ -354,7 +354,7 @@
       "flag": "🇸🇳"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760430",
@@ -375,7 +375,7 @@
       "flag": "🇳🇴"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760433",
@@ -396,7 +396,7 @@
       "flag": "🇩🇿"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760431",
@@ -417,7 +417,7 @@
       "flag": "🇯🇴"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760435",
@@ -438,7 +438,7 @@
       "flag": "🇨🇩"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760437",
@@ -459,7 +459,7 @@
       "flag": "🇭🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760434",
@@ -480,7 +480,7 @@
       "flag": "🇵🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760436",
@@ -501,7 +501,7 @@
       "flag": "🇨🇴"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.302Z"
+    "updatedAt": "2026-06-24T03:57:24.569Z"
   },
   {
     "id": "760438",
@@ -522,7 +522,7 @@
       "flag": "🇿🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760439",
@@ -543,7 +543,7 @@
       "flag": "🇧🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760440",
@@ -564,7 +564,7 @@
       "flag": "🇶🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760441",
@@ -585,7 +585,7 @@
       "flag": "🇰🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760442",
@@ -606,7 +606,7 @@
       "flag": "🇦🇺"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760445",
@@ -627,7 +627,7 @@
       "flag": "🇲🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760444",
@@ -648,7 +648,7 @@
       "flag": "🇭🇹"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760443",
@@ -669,7 +669,7 @@
       "flag": "🇵🇾"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760447",
@@ -690,7 +690,7 @@
       "flag": "🇸🇪"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760448",
@@ -711,7 +711,7 @@
       "flag": "🇨🇮"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760446",
@@ -732,7 +732,7 @@
       "flag": "🇨🇼"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760449",
@@ -753,7 +753,7 @@
       "flag": "🇯🇵"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760453",
@@ -774,7 +774,7 @@
       "flag": "🇸🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760451",
@@ -795,7 +795,7 @@
       "flag": "🇮🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760450",
@@ -816,7 +816,7 @@
       "flag": "🇨🇻"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760452",
@@ -837,7 +837,7 @@
       "flag": "🇪🇬"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760456",
@@ -858,7 +858,7 @@
       "flag": "🇦🇹"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760457",
@@ -879,7 +879,7 @@
       "flag": "🇮🇶"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760454",
@@ -900,7 +900,7 @@
       "flag": "🇸🇳"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760455",
@@ -921,7 +921,7 @@
       "flag": "🇩🇿"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760461",
@@ -942,7 +942,7 @@
       "flag": "🇺🇿"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760458",
@@ -963,7 +963,7 @@
       "flag": "🇬🇭"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760460",
@@ -984,7 +984,7 @@
       "flag": "🇭🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760459",
@@ -1005,7 +1005,7 @@
       "flag": "🇨🇩"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760462",
@@ -1026,7 +1026,7 @@
       "flag": "🇶🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760463",
@@ -1047,7 +1047,7 @@
       "flag": "🇨🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760464",
@@ -1068,7 +1068,7 @@
       "flag": "🇭🇹"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760465",
@@ -1089,7 +1089,7 @@
       "flag": "🇧🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760467",
@@ -1110,7 +1110,7 @@
       "flag": "🇲🇽"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760466",
@@ -1131,7 +1131,7 @@
       "flag": "🇰🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.394Z"
+    "updatedAt": "2026-06-24T03:57:24.663Z"
   },
   {
     "id": "760473",
@@ -1152,7 +1152,7 @@
       "flag": "🇨🇮"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760468",
@@ -1173,7 +1173,7 @@
       "flag": "🇩🇪"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760471",
@@ -1194,7 +1194,7 @@
       "flag": "🇸🇪"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760472",
@@ -1215,7 +1215,7 @@
       "flag": "🇳🇱"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760469",
@@ -1236,7 +1236,7 @@
       "flag": "🇦🇺"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760470",
@@ -1257,7 +1257,7 @@
       "flag": "🇺🇸"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760475",
@@ -1278,7 +1278,7 @@
       "flag": "🇫🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760474",
@@ -1299,7 +1299,7 @@
       "flag": "🇮🇶"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760478",
@@ -1320,7 +1320,7 @@
       "flag": "🇸🇦"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760479",
@@ -1341,7 +1341,7 @@
       "flag": "🇪🇸"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760476",
@@ -1362,7 +1362,7 @@
       "flag": "🇮🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760477",
@@ -1383,7 +1383,7 @@
       "flag": "🇧🇪"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760480",
@@ -1404,7 +1404,7 @@
       "flag": "🇬🇭"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760485",
@@ -1425,7 +1425,7 @@
       "flag": "🏴󠁧󠁢󠁥󠁮󠁧󠁿"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760481",
@@ -1446,7 +1446,7 @@
       "flag": "🇵🇹"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760482",
@@ -1467,7 +1467,7 @@
       "flag": "🇺🇿"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760484",
@@ -1488,7 +1488,7 @@
       "flag": "🇦🇹"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760483",
@@ -1509,7 +1509,7 @@
       "flag": "🇦🇷"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.523Z"
+    "updatedAt": "2026-06-24T03:57:24.756Z"
   },
   {
     "id": "760486",
@@ -1529,7 +1529,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.529Z"
+    "updatedAt": "2026-06-24T03:57:24.761Z"
   },
   {
     "id": "760487",
@@ -1549,7 +1549,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.529Z"
+    "updatedAt": "2026-06-24T03:57:24.761Z"
   },
   {
     "id": "760489",
@@ -1559,8 +1559,8 @@
     "city": "Foxborough, Massachusetts",
     "country": "USA",
     "home": {
-      "code": "TBD",
-      "name": "Germany",
+      "code": "1E",
+      "name": "Group E Winner",
       "flag": "🏳️"
     },
     "away": {
@@ -1569,7 +1569,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.529Z"
+    "updatedAt": "2026-06-24T03:57:24.761Z"
   },
   {
     "id": "760488",
@@ -1589,7 +1589,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.529Z"
+    "updatedAt": "2026-06-24T03:57:24.761Z"
   },
   {
     "id": "760490",
@@ -1609,7 +1609,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.529Z"
+    "updatedAt": "2026-06-24T03:57:24.761Z"
   },
   {
     "id": "760492",
@@ -1629,7 +1629,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.529Z"
+    "updatedAt": "2026-06-24T03:57:24.761Z"
   },
   {
     "id": "760491",
@@ -1639,8 +1639,8 @@
     "city": "Mexico City",
     "country": "Mexico",
     "home": {
-      "code": "TBD",
-      "name": "Mexico",
+      "code": "1A",
+      "name": "Group A Winner",
       "flag": "🏳️"
     },
     "away": {
@@ -1649,7 +1649,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.529Z"
+    "updatedAt": "2026-06-24T03:57:24.761Z"
   },
   {
     "id": "760495",
@@ -1669,7 +1669,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.529Z"
+    "updatedAt": "2026-06-24T03:57:24.761Z"
   },
   {
     "id": "760493",
@@ -1689,7 +1689,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.529Z"
+    "updatedAt": "2026-06-24T03:57:24.761Z"
   },
   {
     "id": "760494",
@@ -1699,8 +1699,8 @@
     "city": "Santa Clara, California",
     "country": "USA",
     "home": {
-      "code": "TBD",
-      "name": "United States",
+      "code": "1D",
+      "name": "Group D Winner",
       "flag": "🏳️"
     },
     "away": {
@@ -1709,7 +1709,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.529Z"
+    "updatedAt": "2026-06-24T03:57:24.761Z"
   },
   {
     "id": "760497",
@@ -1729,7 +1729,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760496",
@@ -1749,7 +1749,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760498",
@@ -1769,7 +1769,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760499",
@@ -1789,7 +1789,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760500",
@@ -1799,8 +1799,8 @@
     "city": "Miami Gardens, Florida",
     "country": "USA",
     "home": {
-      "code": "TBD",
-      "name": "Argentina",
+      "code": "1J",
+      "name": "Group J Winner",
       "flag": "🏳️"
     },
     "away": {
@@ -1809,7 +1809,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760501",
@@ -1829,7 +1829,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760502",
@@ -1849,7 +1849,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760503",
@@ -1869,7 +1869,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760504",
@@ -1889,7 +1889,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760505",
@@ -1909,7 +1909,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760506",
@@ -1929,7 +1929,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760507",
@@ -1949,7 +1949,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760509",
@@ -1969,7 +1969,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760508",
@@ -1989,7 +1989,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.593Z"
+    "updatedAt": "2026-06-24T03:57:24.835Z"
   },
   {
     "id": "760510",
@@ -2009,7 +2009,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.650Z"
+    "updatedAt": "2026-06-24T03:57:24.901Z"
   },
   {
     "id": "760511",
@@ -2029,7 +2029,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.650Z"
+    "updatedAt": "2026-06-24T03:57:24.901Z"
   },
   {
     "id": "760512",
@@ -2049,7 +2049,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.650Z"
+    "updatedAt": "2026-06-24T03:57:24.901Z"
   },
   {
     "id": "760513",
@@ -2069,7 +2069,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.650Z"
+    "updatedAt": "2026-06-24T03:57:24.901Z"
   },
   {
     "id": "760514",
@@ -2089,7 +2089,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.650Z"
+    "updatedAt": "2026-06-24T03:57:24.901Z"
   },
   {
     "id": "760515",
@@ -2109,7 +2109,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.650Z"
+    "updatedAt": "2026-06-24T03:57:24.901Z"
   },
   {
     "id": "760516",
@@ -2129,7 +2129,7 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.749Z"
+    "updatedAt": "2026-06-24T03:57:24.994Z"
   },
   {
     "id": "760517",
@@ -2149,6 +2149,6 @@
       "flag": "🏳️"
     },
     "status": "SCHEDULED",
-    "updatedAt": "2026-06-24T01:20:06.749Z"
+    "updatedAt": "2026-06-24T03:57:24.994Z"
   }
 ]

--- a/packages/core/test/bracket-parse.test.ts
+++ b/packages/core/test/bracket-parse.test.ts
@@ -5,10 +5,33 @@ import type { Team } from '../src/types';
 const T = (name: string, code: string, flag = '🏳️'): Team => ({ name, code, flag });
 
 describe('parseTeamSlot', () => {
-  it('maps ESPN pre-draw nations to seed slots (never confirmed team)', () => {
+  it('maps ESPN pre-draw host nations to group-winner slots', () => {
     expect(parseTeamSlot(T('Mexico', 'MEX', '🇲🇽'))).toEqual({
+      kind: 'group',
+      position: 1,
+      group: 'A',
+    });
+    expect(parseTeamSlot(T('Germany', 'GER', '🇩🇪'))).toEqual({
+      kind: 'group',
+      position: 1,
+      group: 'E',
+    });
+    expect(parseTeamSlot(T('United States', 'USA', '🇺🇸'))).toEqual({
+      kind: 'group',
+      position: 1,
+      group: 'D',
+    });
+    expect(parseTeamSlot(T('Argentina', 'ARG', '🇦🇷'))).toEqual({
+      kind: 'group',
+      position: 1,
+      group: 'J',
+    });
+  });
+
+  it('maps other ESPN pre-draw nations to generic seed slots', () => {
+    expect(parseTeamSlot(T('France', 'FRA', '🇫🇷'))).toEqual({
       kind: 'seed',
-      label: 'Mexico',
+      label: 'France',
       code: 'TBD',
     });
   });

--- a/packages/core/test/bracket-resolve.test.ts
+++ b/packages/core/test/bracket-resolve.test.ts
@@ -77,6 +77,28 @@ describe('buildBracketView', () => {
     expect(seeds.every((p) => p.status === 'tbd')).toBe(true);
   });
 
+  it('confirms seed slots when live overlay carries a real nation flag', () => {
+    const seedIds = new Map([
+      ['760489', 'Germany'],
+      ['760491', 'Mexico'],
+      ['760494', 'United States'],
+      ['760500', 'Argentina'],
+    ]);
+    const merged = baseKo.map((m) => {
+      const label = seedIds.get(m.id);
+      if (!label) return m;
+      return {
+        ...m,
+        home: { code: label.slice(0, 3).toUpperCase(), name: label, flag: '🇩🇪' },
+      };
+    });
+    const view = buildBracketView(topology, merged, [], true, false);
+    const r32 = view.stages.find((s) => s.stage === 'R32')!;
+    const germany = r32.matches.find((m) => m.matchId === '760489')?.home;
+    expect(germany?.status).toBe('confirmed');
+    expect(germany?.flag).toBe('🇩🇪');
+  });
+
   it('projects a group slot only when the group is fully played', () => {
     const tables: GroupStandings[] = [
       {

--- a/packages/core/test/bracket-resolve.test.ts
+++ b/packages/core/test/bracket-resolve.test.ts
@@ -67,36 +67,59 @@ describe('buildBracketView', () => {
     expect(confirmed?.status).toBe('confirmed');
   });
 
-  it('never confirms seed slots from the static bundle', () => {
+  it('never confirms host paths from the static bundle', () => {
     const view = buildBracketView(topology, baseKo, [], true, true);
     const r32 = view.stages.find((s) => s.stage === 'R32')!;
-    const seeds = r32.matches
-      .flatMap((m) => [m.home, m.away])
-      .filter((p) => ['Germany', 'Mexico', 'United States', 'Argentina'].includes(p.label));
-    expect(seeds.length).toBeGreaterThan(0);
-    expect(seeds.every((p) => p.status === 'tbd')).toBe(true);
+    const hostPaths = ['760491', '760489', '760494', '760500'];
+    for (const id of hostPaths) {
+      const node = r32.matches.find((m) => m.matchId === id);
+      expect(node?.home.status).toBe('tbd');
+      expect(node?.home.flag).toBe('🏳️');
+    }
   });
 
-  it('confirms seed slots when live overlay carries a real nation flag', () => {
-    const seedIds = new Map([
-      ['760489', 'Germany'],
-      ['760491', 'Mexico'],
-      ['760494', 'United States'],
-      ['760500', 'Argentina'],
-    ]);
-    const merged = baseKo.map((m) => {
-      const label = seedIds.get(m.id);
-      if (!label) return m;
-      return {
-        ...m,
-        home: { code: label.slice(0, 3).toUpperCase(), name: label, flag: '🇩🇪' },
-      };
+  it('topology maps host nations to group-winner refs', () => {
+    expect(topology.matches.find((n) => n.matchId === '760491')?.home).toEqual({
+      kind: 'group',
+      position: 1,
+      group: 'A',
     });
-    const view = buildBracketView(topology, merged, [], true, false);
-    const r32 = view.stages.find((s) => s.stage === 'R32')!;
-    const germany = r32.matches.find((m) => m.matchId === '760489')?.home;
-    expect(germany?.status).toBe('confirmed');
-    expect(germany?.flag).toBe('🇩🇪');
+    expect(topology.matches.find((n) => n.matchId === '760489')?.home).toEqual({
+      kind: 'group',
+      position: 1,
+      group: 'E',
+    });
+    expect(topology.matches.find((n) => n.matchId === '760494')?.home).toEqual({
+      kind: 'group',
+      position: 1,
+      group: 'D',
+    });
+    expect(topology.matches.find((n) => n.matchId === '760500')?.home).toEqual({
+      kind: 'group',
+      position: 1,
+      group: 'J',
+    });
+  });
+
+  it('projects a host group-winner slot when the group is fully played', () => {
+    const tables: GroupStandings[] = [
+      {
+        group: 'A',
+        rows: [
+          { team: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' }, played: 3, won: 3, drawn: 0, lost: 0, goalsFor: 5, goalsAgainst: 1, goalDiff: 4, points: 9 },
+          { team: { code: 'KOR', name: 'South Korea', flag: '🇰🇷' }, played: 3, won: 1, drawn: 0, lost: 2, goalsFor: 2, goalsAgainst: 4, goalDiff: -2, points: 3 },
+          { team: { code: 'CZE', name: 'Czechia', flag: '🇨🇿' }, played: 3, won: 1, drawn: 0, lost: 2, goalsFor: 2, goalsAgainst: 3, goalDiff: -1, points: 3 },
+          { team: { code: 'RSA', name: 'South Africa', flag: '🇿🇦' }, played: 3, won: 1, drawn: 0, lost: 2, goalsFor: 1, goalsAgainst: 2, goalDiff: -1, points: 3 },
+        ],
+      },
+    ];
+    const view = buildBracketView(topology, baseKo, tables, false, false);
+    const mexicoSlot = view.stages
+      .find((s) => s.stage === 'R32')
+      ?.matches.find((m) => m.matchId === '760491')?.home;
+    expect(mexicoSlot?.code).toBe('MEX');
+    expect(mexicoSlot?.flag).toBe('🇲🇽');
+    expect(mexicoSlot?.status).toBe('projected');
   });
 
   it('projects a group slot only when the group is fully played', () => {


### PR DESCRIPTION
## Summary
- Map ESPN pre-draw nation labels on R32 fixtures to **group-winner** topology refs (not frozen `seed` labels):
  - Mexico → Group A winner
  - Germany → Group E winner
  - United States → Group D winner
  - Argentina → Group J winner
- Slots render like other group paths (`Group E winner`) until the group finishes, then **project from live standings** with flags — only if that team actually tops the group
- Regenerated `bracket.2026.json` (no `seed` nodes remain)

## Why not live-seed overlay?
PR #34’s earlier approach confirmed flags whenever ESPN named a nation on the fixture — that would **freeze** the slot even if they failed to win the group. Group-winner refs follow the same rules as every other group slot.

## Test plan
- [x] `pnpm -r build && pnpm -r test` green
- [x] Parse + topology tests for A/E/D/J mapping
- [x] Projection test when Group A fully played
- [ ] After Jun 27: host paths fill from standings when groups complete