### PR TITLE
fix(core): show calendar date on bracket kickoff times

### DIFF
--- a/packages/core/src/bracket/format.ts
+++ b/packages/core/src/bracket/format.ts
@@ -35,6 +35,10 @@ function statusTail(m: BracketMatchView['match']): string {
   return '';
 }
 
+function formatBracketKickoff(iso: string, opts: BracketFormatOpts): string {
+  return formatKickoff(iso, { tz: opts.tz, locale: opts.locale, date: true });
+}
+
 /** One bracket match line for list or tree output. */
 export function formatBracketMatchLine(mv: BracketMatchView, opts: BracketFormatOpts = {}): string {
   const flags = opts.flags !== false;
@@ -45,7 +49,7 @@ export function formatBracketMatchLine(mv: BracketMatchView, opts: BracketFormat
     return `  ${home}  ${scoreline(m)}  ${away}${statusTail(m)}`;
   }
   const kickoff = mv.kickoff
-    ? formatKickoff(mv.kickoff, { tz: opts.tz, locale: opts.locale })
+    ? formatBracketKickoff(mv.kickoff, opts)
     : '';
   return `  ${home} vs ${away}${kickoff ? ` · ${kickoff}` : ''}`;
 }
@@ -184,7 +188,7 @@ export function formatBracketCompactLine(mv: BracketMatchView, opts: BracketForm
   const m = mv.match;
   const mid = isFinished(m.status) || isLive(m.status) ? scoreline(m) : 'vs';
   const tail = m.status === 'SCHEDULED' && mv.kickoff
-    ? ` · ${formatKickoff(mv.kickoff, { tz: opts.tz, locale: opts.locale })}`
+    ? ` · ${formatBracketKickoff(mv.kickoff, opts)}`
     : statusTail(m);
   return `${stageLabelI18n(opts.locale, mv.stage)} · ${home} ${mid} ${away}${tail}`;
 }

--- a/packages/core/src/time.ts
+++ b/packages/core/src/time.ts
@@ -39,6 +39,8 @@ export function resolveTz(explicit?: string): string | undefined {
 export interface FormatOpts {
   tz?: string;
   locale?: string;
+  /** Include month and day (for multi-week schedules like the knockout bracket). */
+  date?: boolean;
 }
 
 /**
@@ -57,12 +59,13 @@ function safeLocale(locale?: string): string {
   }
 }
 
-/** Format a kickoff like "Thu 19:00" in the target timezone/locale. */
+/** Format a kickoff like "Thu 19:00", or "Sat, Jul 4, 17:00" when `date` is set. */
 export function formatKickoff(iso: string, opts: FormatOpts = {}): string {
   const tz = resolveTz(opts.tz);
   const locale = safeLocale(opts.locale);
   return new Intl.DateTimeFormat(locale, {
     weekday: 'short',
+    ...(opts.date ? { month: 'short', day: 'numeric' } : {}),
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,

--- a/packages/core/test/bracket-format.test.ts
+++ b/packages/core/test/bracket-format.test.ts
@@ -39,7 +39,10 @@ describe('formatBracketMatchLine', () => {
       { view: { stages, degraded: true, standingsDegraded: false } },
       { locale: 'en', tz: 'UTC' },
     );
-    expect(card).toContain('Sat 17:00');
+    expect(card).toContain('Sat');
+    expect(card).toMatch(/Jul/);
+    expect(card).toMatch(/4/);
+    expect(card).toContain('17:00');
   });
 
   it('formatShareBracket compact style uses one line per match with kickoff day', () => {
@@ -49,7 +52,9 @@ describe('formatBracketMatchLine', () => {
       { style: 'compact', locale: 'en', tz: 'UTC' },
     );
     expect(card).toContain('Round of 32 · 🇨🇿 Czechia vs Mexico 🇲🇽');
-    expect(card).toContain('Sat 17:00');
+    expect(card).toMatch(/Jul/);
+    expect(card).toMatch(/4/);
+    expect(card).toContain('17:00');
     expect(card.split('\n').filter((l) => l.includes('vs')).length).toBe(1);
   });
 });

--- a/packages/core/test/time.test.ts
+++ b/packages/core/test/time.test.ts
@@ -35,6 +35,12 @@ describe('formatKickoff', () => {
       formatKickoff(iso, { tz: 'UTC', locale: 'en' }),
     );
   });
+  it('includes month and day when date is set', () => {
+    const s = formatKickoff('2026-07-04T17:00:00Z', { tz: 'UTC', locale: 'en', date: true });
+    expect(s).toMatch(/Jul/);
+    expect(s).toMatch(/4/);
+    expect(s).toMatch(/17/);
+  });
 });
 
 describe('localDate', () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -341,7 +341,7 @@ export async function toolGetBracket(
     resolveAdapter(args),
     filter ? { stage: filter as Stage, lang: args.lang } : { lang: args.lang },
   );
-  let text = formatBracketList(view, { footer: false, locale: args.lang });
+  let text = formatBracketList(view, { footer: false, locale: args.lang, tz: args.tz });
   if (degraded) {
     text += `\n\n(${t(args.lang, 'bracket.degraded')})`;
   } else if (standingsDegraded) {

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -251,6 +251,17 @@ describe('toolGetBracket', () => {
     expect(data.view.stages[0]?.stage).toBe('F');
     expect(data.view.stages[0]?.matches).toHaveLength(1);
   });
+
+  it('honors tz for kickoff calendar dates', async () => {
+    const utc = await toolGetBracket({ tz: 'UTC', adapter: fakeAdapter({ throws: true }) });
+    const mx = await toolGetBracket({
+      tz: 'America/Mexico_City',
+      adapter: fakeAdapter({ throws: true }),
+    });
+    // R32 760501 kicks off 2026-07-04T01:30Z — Jul 4 UTC, Jul 3 in Mexico City.
+    expect(utc.text).toContain('Jul 4, 01:30');
+    expect(mx.text).toContain('Jul 3, 19:30');
+  });
 });
 
 describe('standingsResourceText (standings:// resource)', () => {


### PR DESCRIPTION
## Summary
- Add optional `date` flag to `formatKickoff` to include month and day of month.
- Use it for bracket list/tree output and share bracket (social + compact).
- `today` / `next` / `match` keep the compact weekday+time format since those views are grouped by day.

## Example
```
🇩🇪 Germany (proj.) vs 3rd (A/B/C/D/F) · Mon, Jun 29, 13:30
```

## Test plan
- [x] `pnpm -r build && pnpm -r typecheck && pnpm -r test`
- [x] `node packages/cli/dist/index.js bracket` — R32 lines show `Jun 28`, `Jun 29`, etc.
- [ ] `claudinho share bracket` — same date format on share cards


Made with [Cursor](https://cursor.com)