### PR TITLE
chore(scripts): add release-qa pre-tag surface renderer

### DIFF
--- a/scripts/release-qa.sh
+++ b/scripts/release-qa.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# release-qa.sh — render EVERY user-facing surface against the live feed, across
+# timezones + all four locales, for a human eyeball BEFORE tagging a release.
+#
+# Why this exists: the 0.8.0 -> 0.8.4 bracket sprawl was five releases because
+# each gap (ambiguous dates, missing host-nation flags, a dropped tz on MCP
+# get_bracket) was found by *using* the feature after it was already live. This
+# makes the "test it on a real terminal first" pass exhaustive and reproducible
+# instead of ad-hoc greps. Its job is to put every surface in front of you — the
+# eyeball is still yours. A few tripwires at the end encode the specific bugs that
+# shipped this cycle so they can't recur silently.
+#
+# Usage:
+#   pnpm -r build && ./scripts/release-qa.sh        # test the artifact about to ship
+#   CLI="claudinho" ./scripts/release-qa.sh         # test the global install instead
+#   CLAUDINHO_COMPETITION=fifa.friendly ./scripts/release-qa.sh   # another competition
+#
+# Exit code: non-zero if a tripwire FAILS (real regression). A degraded/unreachable
+# feed downgrades tripwires to SKIP (exit 0) — a network blip must not block a release.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DIST="$ROOT/packages/cli/dist/index.js"
+export CLAUDINHO_COMPETITION="${CLAUDINHO_COMPETITION:-fifa.world}"
+LANGS=(en es pt fr)
+TEAM="${TEAM:-MEX}"
+GROUP="${GROUP:-A}"
+
+# Default to the built dist (tests exactly what ships); CLI=claudinho overrides.
+cli() { if [ -n "${CLI:-}" ]; then $CLI "$@"; else node "$DIST" "$@"; fi; }
+
+bold()    { printf '\033[1m%s\033[0m\n' "$1"; }
+banner()  { printf '\n\033[1;36m━━━ %s ━━━\033[0m\n' "$1"; }
+run()     { printf '\033[2m$ claudinho %s\033[0m\n' "$*"; cli "$@"; echo; }
+
+if [ -z "${CLI:-}" ] && [ ! -f "$DIST" ]; then
+  echo "✗ build first:  pnpm -r build   (or run with CLI=claudinho)"; exit 1
+fi
+
+bold "release-qa · competition=$CLAUDINHO_COMPETITION · $(cli --version 2>/dev/null)"
+echo "Read every section below. Then run the release. Tripwires summarized at the end."
+
+# ── 1. The knockout bracket (the surface that sprawled) ──────────────────────
+banner "BRACKET — list + tree (en)"
+run bracket
+run bracket --tree
+
+banner "BRACKET — all four locales (team names stay EN by design; labels/dates localize)"
+for L in "${LANGS[@]}"; do run bracket --lang "$L"; done
+
+banner "BRACKET — timezone threading (date must land in the CALLER's zone, not server-local)"
+run bracket --tz UTC
+run bracket --tz Asia/Tokyo
+
+# ── 2. Share bracket (pasteable, disclaimer non-optional) ────────────────────
+banner "SHARE BRACKET — social + compact + a locale"
+run share bracket
+run share bracket --style compact
+run share bracket --lang es
+
+# ── 3. Day / score / standings surfaces ──────────────────────────────────────
+banner "TODAY / LIVE (en + es spot-check)"
+run today
+run today --lang es
+run live
+
+banner "NEXT ($TEAM) / TABLE ($GROUP) / all tables"
+run next "$TEAM"
+run table "$GROUP"
+run table
+
+banner "SHARE — table + live"
+run share table "$GROUP"
+run share live
+
+# ── 4. Statusline (reads the local micro-cache; may be quiet off-match) ───────
+banner "STATUSLINE (prompt)"
+run prompt
+
+# ── 5. Tripwires — the specific bugs that shipped this cycle ──────────────────
+banner "TRIPWIRES"
+PASS=0; FAIL=0; SKIP=0
+BR_EN="$(cli bracket 2>/dev/null)"
+BR_UTC="$(cli bracket --tz UTC 2>/dev/null)"
+BR_TYO="$(cli bracket --tz Asia/Tokyo 2>/dev/null)"
+SB="$(cli share bracket 2>/dev/null)"
+SBC="$(cli share bracket --style compact 2>/dev/null)"
+
+check() { # name ; pass-condition already evaluated into $1=ok/no
+  if [ "$1" = "ok" ]; then printf '  \033[32m✓ PASS\033[0m  %s\n' "$2"; PASS=$((PASS+1))
+  else printf '  \033[31m✗ FAIL\033[0m  %s\n' "$2"; FAIL=$((FAIL+1)); fi
+}
+
+# If the feed is degraded/unreachable, the bracket loses its R32 structure — skip
+# tripwires rather than fail a release on a transient network issue (fail-closed,
+# never cache a transient error as a real result).
+if ! grep -q "Round of 32" <<<"$BR_EN" || grep -qi "degraded\|feed.*down\|unreachable" <<<"$BR_EN"; then
+  printf '  \033[33m⚠ SKIP\033[0m  feed degraded/unreachable — eyeball the sections above manually\n'
+  SKIP=4
+else
+  # T1: bracket kickoffs show a CALENDAR DATE (month), not a bare weekday (0.8.4)
+  grep -qE "(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)" <<<"$BR_EN" \
+    && check ok  "bracket kickoffs show a calendar month (unambiguous over the 3-week span)" \
+    || check no  "bracket kickoffs show a calendar month (unambiguous over the 3-week span)"
+  # T2: tz is actually threaded into the rendered date/time (0.8.4 MCP miss)
+  [ "$BR_UTC" != "$BR_TYO" ] \
+    && check ok  "bracket output differs UTC vs Asia/Tokyo (tz threaded into rendering)" \
+    || check no  "bracket output differs UTC vs Asia/Tokyo (tz threaded into rendering)"
+  # T3/T4: the non-affiliation disclaimer is non-optional on share cards (legal)
+  grep -qi "not affiliated with FIFA" <<<"$SB" \
+    && check ok  "share bracket carries the non-affiliation disclaimer" \
+    || check no  "share bracket carries the non-affiliation disclaimer"
+  grep -qi "not affiliated with FIFA" <<<"$SBC" \
+    && check ok  "share bracket --style compact carries the disclaimer" \
+    || check no  "share bracket --style compact carries the disclaimer"
+fi
+
+echo
+bold "tripwires: $PASS passed · $FAIL failed · $SKIP skipped"
+echo "NOTE: this covers CLI/share rendering. MCP arg-threading (tz/lang on get_bracket"
+echo "et al.) is guarded by packages/mcp/test/tools.test.ts — keep that green too."
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Why

Today's bracket work shipped as 0.8.0 plus four reactive dot-releases (0.8.1–0.8.4) because each gap — ambiguous dates, missing host-nation flags, a dropped `tz` on MCP `get_bracket` — was found by *using* the feature after it was live. This makes the "test it on a real terminal first" pass (the one that ended the earlier dot-release streak) **exhaustive and reproducible** instead of ad-hoc greps.

## What it does

`./scripts/release-qa.sh` renders **every** user-facing CLI/share surface against the **live feed**, across:
- **2 timezones** (UTC vs Asia/Tokyo — catches tz not threaded into rendered dates)
- **all 4 locales** (en/es/pt/fr)

then runs **tripwires** for this cycle's exact bugs:
- ✓ bracket kickoffs show a calendar **month/day** (unambiguous over the 3-week span)
- ✓ bracket output **differs by tz** (tz actually threaded)
- ✓ `share bracket` + `--style compact` carry the **non-affiliation disclaimer**

It **SKIPs** (exit 0) rather than fails on a degraded/unreachable feed, so a network blip never blocks a release. Defaults to the built `dist` (`CLI=claudinho` to test the global install).

## Notes
- Covers CLI/share rendering; MCP arg-threading stays guarded by `packages/mcp/test/tools.test.ts`.
- Companion process docs (Definition of Done, Release cadence) live in the internal AGENTS guide.

## Test plan
- [x] `pnpm -r build && ./scripts/release-qa.sh` → 4/4 tripwires pass, exit 0, renders all surfaces

Made with Claude Code.