### PR TITLE
chore: process guardrails aligned with release-qa

### DIFF
--- a/.cursor/rules/bundle-bracket-pr.mdc
+++ b/.cursor/rules/bundle-bracket-pr.mdc
@@ -33,6 +33,11 @@ Before marking a data-heavy feature merge-ready, run **`pnpm -r build && pnpm -r
 - When knockout fetch fails but standings succeed: set `source` from standings provider.
 - Share/MCP: inner `formatBracketList({ footer: false })`, outer layer adds attribution/notices **once**.
 - CLI/MCP wrappers: option types must match the formatter (`ShareBracketOptions`, not `ShareSnippetOptions`).
+- **Surface parity:** see `.cursor/rules/surface-parity.mdc` — every bracket formatter path passes `tz` + `locale`.
+
+## Pre-merge QA
+
+After `pnpm -r build`, run **`pnpm release:qa`** (`scripts/release-qa.sh`). Eyeball every section; tripwires at the end encode the 0.8.x bracket regressions (calendar month, tz threading, share disclaimer).
 
 ## Adversarial tests (add when touching bracket/schedule)
 
@@ -42,4 +47,8 @@ Before marking a data-heavy feature merge-ready, run **`pnpm -r build && pnpm -r
 | `fetchWindow` throws, standings OK | Projected groups + `source` set |
 | Bundle-only bracket | No real flags in R32+ slots |
 | Group at 0 games played | Slots stay `tbd`, no `(proj.)` |
+| Group at 2/3 played, standings live | Leaders show flags + `(proj.)` |
+| `toolGetBracket` `tz: UTC` vs `America/Mexico_City` | Calendar date/time differs on cross-midnight kickoff |
+| Knockout kickoffs span >1 week | Output includes month + day (not weekday-only) |
+| `formatShareBracket` social + compact | Same date format as CLI list |
 | `formatShareBracket` / `toolGetBracket` | Each disclaimer line once |

--- a/.cursor/rules/release-discipline.mdc
+++ b/.cursor/rules/release-discipline.mdc
@@ -9,7 +9,7 @@ alwaysApply: true
 
 - **One user-facing feature → one minor.** Stack review fixes (tz, dates, guards) into the **same PR** before merge when they belong to the same feature.
 - Do **not** tag npm until CI is green **and** `pnpm release:qa` passes (tripwires at the end must be 0 failed).
-- Before tagging: `git diff main` must not include accidental `docs/PRD.md`, `.env`, or agent guides.
+- Before tagging: `git diff main` must not include accidental internal docs (`docs/`), `.env`, or agent guides (`AGENTS.md`/`CLAUDE.md`).
 
 ## Gitignored paths (never publish)
 

--- a/.cursor/rules/release-discipline.mdc
+++ b/.cursor/rules/release-discipline.mdc
@@ -1,0 +1,27 @@
+---
+description: Release batching, gitignore policy, and pre-tag checks
+alwaysApply: true
+---
+
+# Release discipline
+
+## One feature, one release
+
+- **One user-facing feature → one minor.** Stack review fixes (tz, dates, guards) into the **same PR** before merge when they belong to the same feature.
+- Do **not** tag npm until CI is green **and** `pnpm release:qa` passes (tripwires at the end must be 0 failed).
+- Before tagging: `git diff main` must not include accidental `docs/PRD.md`, `.env`, or agent guides.
+
+## Gitignored paths (never publish)
+
+`docs/`, `AGENTS.md`, and `CLAUDE.md` are **local-only**.
+
+- Doc reviews → update **tracked** surfaces: `README`, MCP tool descriptions, `.cursor/rules/`.
+- **Never** add `!docs/…` exceptions to `.gitignore` without explicit maintainer approval.
+
+## Bracket / live-formatting ship checklist
+
+Before merge **or** release of bracket or kickoff-formatting work:
+
+1. Adversarial tests: 0 games, mid-tournament (2/3 played), degraded standings.
+2. **Surface parity:** CLI `bracket` + MCP `get_bracket` + `share bracket` all pass `tz` and show calendar dates on multi-week knockouts.
+3. After `pnpm -r build`, run **`pnpm release:qa`** and eyeball the rendered sections; keep `packages/mcp/test/tools.test.ts` green for MCP arg threading.

--- a/.cursor/rules/surface-parity.mdc
+++ b/.cursor/rules/surface-parity.mdc
@@ -1,0 +1,38 @@
+---
+description: CLI, MCP, and share must pass the same format opts (tz, locale, flags)
+globs: packages/{cli,mcp,core}/**/*
+alwaysApply: false
+---
+
+# Surface parity (CLI / MCP / share)
+
+Any user-visible formatter change must land on **all three surfaces** before merge:
+
+| Surface | Verify |
+|---------|--------|
+| CLI | `packages/cli` command + `packages/cli/test/` |
+| MCP | `toolGet*` in `packages/mcp/src/tools.ts` + `packages/mcp/test/tools.test.ts` |
+| Share | `formatShare*` + `packages/mcp/test/share.test.ts` |
+
+`scripts/release-qa.sh` exercises CLI + share rendering across locales and timezones; MCP arg threading is **not** rendered there — guard it with unit tests.
+
+## Format opts invariant
+
+If a core formatter accepts `tz`, `locale`, `flags`, or `date`, **every wrapper** passes them from `CliConfig` / `CommonOpts`.
+
+```typescript
+// ❌ BAD — locale only; tz silently drops to server local
+formatBracketList(view, { footer: false, locale: args.lang });
+
+// ✅ GOOD
+formatBracketList(view, { footer: false, locale: args.lang, tz: args.tz });
+// or reuse fmtOpts(args) where shapes align
+```
+
+## Regression tests
+
+When adding a format option (e.g. `date: true` on `formatKickoff`):
+
+- Add a **core** unit test for the option.
+- Add an **MCP tool test** proving `tz` changes output (e.g. UTC vs `America/Mexico_City` on a cross-midnight kickoff).
+- Update share tests if `formatShareBracket` / compact lines are affected.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,18 @@
 - [ ] Bracket index ↔ ESPN winner refs verified (guard test if assumption can't be live-checked)
 - [ ] Provider `source` set on every hybrid live path (knockout + standings)
 - [ ] Share/MCP/CLI user-visible text: attribution and degraded notices appear once
+- [ ] **Surface parity:** MCP tools pass `tz` / `locale` to core formatters (see `.cursor/rules/surface-parity.mdc`)
+- [ ] Adversarial cases from `.cursor/rules/bundle-bracket-pr.mdc` covered by tests where applicable
+
+### Bracket / formatting PRs — release QA (after build)
+
+- [ ] `pnpm release:qa` — all tripwires pass (calendar month on kickoffs, tz differs UTC vs Asia/Tokyo, share disclaimer present)
+- [ ] `packages/mcp/test/tools.test.ts` green for any MCP tool you touched (esp. `toolGetBracket` tz)
+
+### Release / docs
+
+- [ ] No gitignored paths committed (`docs/`, `AGENTS.md`, `CLAUDE.md`) — update README / MCP descriptions / cursor rules instead
+- [ ] Review fixes for the same feature batched in this PR (avoid follow-up patch releases)
 
 ### Assumptions
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "pnpm -r test",
     "lint": "biome lint .",
     "typecheck": "pnpm -r typecheck",
-    "dev": "pnpm -r --parallel dev"
+    "dev": "pnpm -r --parallel dev",
+    "release:qa": "bash scripts/release-qa.sh"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0"


### PR DESCRIPTION
## Summary
- Add always-on **release-discipline** cursor rule: one feature per minor, gitignore policy, pre-tag checklist pointing at `pnpm release:qa`.
- Add **surface-parity** rule: CLI / MCP / share must pass the same format opts; MCP `tz` regression tests required when format options change.
- Extend **bundle-bracket-pr** adversarial table (mid-tournament, tz, calendar dates) and link to `scripts/release-qa.sh`.
- Update PR template with release QA, surface parity, and docs/release sections.
- Add `pnpm release:qa` alias (builds on #37's `scripts/release-qa.sh`).

## Test plan
- [x] `pnpm -r build && pnpm release:qa` — 4/4 tripwires pass
- [x] No duplicate smoke script (uses existing `release-qa.sh` only)


Made with [Cursor](https://cursor.com)