### PR TITLE
docs: publish AGENTS.md + CLAUDE.md as tracked example guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ dist-portable/
 # internal working docs / dev specs — kept local, never published
 docs/
 
-# agent guides — kept local, never published
-AGENTS.md
-CLAUDE.md
+# maintainer's private notebook — auto-loaded locally via CLAUDE.local.md.
+# The public agent guides (AGENTS.md, CLAUDE.md) ARE tracked; only the local
+# notebook + overrides stay private.
+CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,158 @@
+# AGENTS.md — Claudinho
+
+Guidance for AI coding agents working **in this repository**. (Standard [AGENTS.md](https://agents.md); Claude Code reads it via `CLAUDE.md`.)
+
+## What this is
+
+Claudinho surfaces the 2026 men's football tournament in developer environments: a **CLI**, a **statusline** (Claude Code **and Cursor CLI** — `init claude`/`init cursor` one-step setup), an **MCP server** (also a **Cursor Marketplace plugin** + cursor.directory listing), a **score-aware hook** (Claude Code `UserPromptSubmit`), live scores/fixtures and **cumulative group standings** (from the provider's standings feed), a **knockout bracket**, read-only **prediction-market signals** (Polymarket odds — informational only), and **shareable terminal snippets** (`claudinho share` — copy-pasteable match **and standings** cards). **Planned:** a desktop **notifier**, a precomputed **AI pundit**, and a small edge **gateway** that polls a data feed once for everyone.
+
+## Stack
+
+- TypeScript, Node ≥ 20, ES modules
+- pnpm workspaces (monorepo) · tsup (build) · vitest (test) · Biome (lint)
+- MCP: `@modelcontextprotocol/sdk`
+- Gateway (_planned_, not yet built): Cloudflare Workers + KV + D1 (`services/gateway`)
+
+## Layout
+
+| Path | Package | Role |
+|---|---|---|
+| `packages/core` | `@claudinho/core` | domain model, provider adapters, normalize, tz, emoji flags, i18n, static schedule, bracket, validators |
+| `packages/cli` | `@claudinho/cli` | the `claudinho` binary (CLI + statusline + hook + cache/refresher) |
+| `packages/mcp` | `@claudinho/mcp` | stdio MCP server |
+| `.cursor-plugin/plugin.json` + `mcp.json` (repo root) | — | Cursor Marketplace **plugin** — wraps `@claudinho/mcp` for cursor.com/marketplace. Plugin version is decoupled from npm (`npx -y @claudinho/mcp` = latest); guarded by `packages/mcp/test/cursor-plugin.test.ts`. |
+| `packages/core/src/data/schedule.2026.json` | — | static fixtures, bundled into clients (regenerate via `pnpm -F @claudinho/core gen:schedule`) |
+| `packages/core/src/markets` | — | prediction-market sidecar: `MarketSignal` model, `isReliableMarketSignal` gate, copy bank, `PolymarketProvider` (read-only public data; event slugs auto-derived per fixture), `mapping.2026.json` (slug overrides only, ships empty) |
+| `packages/core/src/share` | — | shareable-snippet formatters: `formatShareSnippet` (match cards) and `formatShareTable` (group-standings cards); disclaimer non-optional, no ANSI, English-only copy in v1 (except `share bracket`, localized) |
+| `.cursor/rules/*.mdc` | — | Cursor rules — the public, contributor-facing engineering guardrails (release discipline, surface parity, bracket/schedule invariants) |
+| `packages/notifier` | `@claudinho/notifier` | _planned_ — `claudinho watch` daemon |
+| `services/gateway` | — | _planned_ — edge API + SSE + cron |
+
+## Commands
+
+- `pnpm install` — install deps
+- `pnpm build` / `pnpm test` / `pnpm typecheck` / `pnpm lint` — across all packages (`lint` = Biome)
+- `pnpm -F @claudinho/core test` — operate on a single package
+- `pnpm release:qa` — pre-tag surface renderer (see "Release readiness")
+
+## Releasing
+
+Releases ship via `.github/workflows/publish.yml` on a `v*` tag, using npm **trusted
+publishing** (OIDC) — **no `NPM_TOKEN`**. A trusted publisher is configured on npm for all
+three packages (`@claudinho/core` · `cli` · `mcp`), all published **with provenance**.
+
+To cut a release:
+
+1. Bump the version in the **three** `package.json` files (`packages/{cli,mcp,core}/package.json`).
+   The cli `--version` and MCP `serverInfo.version` are injected from package.json at build time
+   (tsup `define` → `process.env.CLAUDINHO_VERSION`), so there are no source constants to touch.
+   **Also bump `packages/mcp/mcpb/manifest.json`** — the `.mcpb` desktop-extension manifest carries
+   its own `version`; a vitest guard (`packages/mcp/test/manifest.test.ts`) fails if it drifts.
+2. `pnpm -r build && pnpm -r typecheck && pnpm -r test && pnpm lint` (CI re-runs these). **For any
+   user-facing change, also run `pnpm release:qa`** and eyeball every surface against the live feed
+   before tagging (see "Release readiness").
+3. Commit, then `git tag vX.Y.Z && git push origin vX.Y.Z`. The workflow gates (build/test/lint +
+   tag==version), then `pnpm -r publish --provenance` ships all three via OIDC (versions already on
+   npm are skipped) and auto-creates the GitHub Release (`gh release create --generate-notes`).
+
+**MCP-affecting releases** (anything that changes a tool's shape or description) also bump
+`packages/mcp/server.json` and re-publish to the MCP Registry (`mcp-publisher publish`).
+
+**Lessons (learned the hard way):**
+- npm deprecated classic "Automation" tokens — use **trusted publishing**, not a token.
+- A brand-new package can't have a trusted publisher pre-configured; its **first** publish must be
+  a manual `pnpm -F @claudinho/<pkg> publish --access public` (enter OTP), then add its trusted
+  publisher for later releases.
+- Account 2FA set to "Authorization and writes" forces an OTP that CI can't supply; trusted
+  publishing (OIDC) sidesteps it entirely.
+
+## Conventions
+
+- Shared domain types live in `@claudinho/core` — never duplicate them.
+- Every data vendor implements the `ProviderAdapter` interface — keep providers swappable.
+- Static data (schedule, groups, flags) ships bundled in clients; only **live state** hits the network.
+- **Standings come from the provider's standings feed, NOT computed from a match window.** The bundled schedule is a resultless skeleton, and clients only fetch a ±1-day live window — so deriving a table from those matches yields a *wrong, partial* table mid-tournament (this was a real bug: groups not playing that day read all-zeros). `table`/`get_standings`/`standings://` go through core `getStandings` → optional `adapter.fetchStandings()` (authoritative cumulative table from ESPN's standings endpoint — the SAME endpoint `fetchGroupMap` already hits, so no new egress). It **fails closed** to a static roster-at-zero flagged `degraded` with no attribution — never a confidently-wrong table. `computeStandings` (match-derived) remains for that fallback only.
+- **`CLAUDINHO_COMPETITION` is a deliberate keeper — do not remove it.** It points the live fetch at another ESPN competition (e.g. `fifa.friendly`) and is woven through both the live fetch and the **hot-path cache key** (the cache is competition-keyed). It looks dormant during the World Cup but is load-bearing — it's the seam for following other tournaments.
+- **The bundled schedule is a resultless skeleton.** No scores/status, no confirmed nations in knockout slots. `sanitizeBundledFixture` restores topology placeholders; `gen:schedule` **fails loud** if any knockout fixture carries a real nation flag. Advancement comes only from the live overlay — clients never invent it from static JSON.
+- Market signals use a separate `MarketProvider` interface (not `ProviderAdapter`). The Polymarket event slug is **derived per fixture** (`fifwc-{home}-{away}-{date}`), so most matches resolve with no mapping; `mapping.2026.json` holds slug **overrides only** (ships empty) and validation **fails closed**. Market-facing copy is English-only in v1 (the approved legal copy bank lives in `core/src/markets/format.ts`).
+- **Shareable snippets** (`claudinho share`, the MCP `get_share_snippet` tool, `core/src/share`) are pure, deterministic **plain-text** artifacts (no ANSI — they get pasted): English-only copy in v1 **except `share bracket`** (localized en/es/pt/fr via `ShareBracketOptions.locale`; the non-affiliation disclaimer + hashtag stay EN as fixed strings), market lines reuse the approved copy bank verbatim (`marketBlock`/`marketLine`, never hand-composed), and the non-affiliation disclaimer is **non-optional** (only the hashtag and install cue are toggleable). They use the same reliable market gate as `today`/`match` and are **never** on the statusline/hook hot path. **`share table <GROUP>`** produces a standings card — facts + emoji flags only, **no market line**; a degraded (roster-only) card carries an explicit not-live notice so it can't paste as real.
+
+## Hard constraints (legal — do not violate)
+
+- **Facts + emoji flags only.** Never add team crests, kits, player photos/likenesses, broadcast footage, or FIFA/Anthropic logos or wordmarks.
+- Keep the dual disclaimer — *"Not affiliated with FIFA or Anthropic"* — on user-facing surfaces.
+- Attribute data providers; respect their rate limits.
+- **Prediction-market data is read-only and informational.** Public market data only — no wallet/auth/CLOB/trading endpoints, no outbound market links (`url` stays `null`). Never frame odds as betting/trading advice (no "bet/wager/value/edge/lock"); keep the *"informational only"* caveat and attribute the provider (Polymarket). Market signals are a **sidecar** — never embedded in `Match`, and never read on the statusline/hook hot path (a regression test enforces this).
+
+## Pre-PR self-review (run before declaring a change "done")
+
+This is the lens an external reviewer uses — apply it yourself first. For changes
+touching money/legal/external APIs, also run an **independent adversarial pass**
+(e.g. a reviewer subagent with fresh eyes on the diff) and self-classify any
+findings **P1/P2/P3**.
+
+1. **Verify external contracts against ground truth.** For any new API/integration,
+   fetch a *real* response and confirm the parser **and the test fixtures** match it.
+   Never ship against an assumed payload shape — green tests built on a wrong fixture
+   prove nothing.
+2. **Apply the change to *every* surface.** Enumerate them: CLI (text **and** `--json`),
+   MCP (structured `data` **and** text), statusline/hook, share, and the READMEs. A behavior
+   that lands on 3 of 4 surfaces is a bug — and "every surface" means each surface's *args*
+   (tz/locale/flags) are threaded, not just that the surface exists.
+3. **Audit the whole touched area against the Hard Constraints — including pre-existing
+   code, not just the diff** (e.g. "attribute data providers" applies to *every*
+   provider, not only the one you added).
+4. **Adversarial failure-mode pass per new code path:** empty / missing / malformed
+   input; transient vs. permanent error (never cache a transient failure as a real
+   "no result"); duplicate / ambiguous data; timeout / deadline / concurrency. Default
+   to **fail-closed**.
+5. **State the worst-case latency/cost of any default-on path** under realistic load
+   (e.g. "N sequential fetches × T timeout") and bound it (deadline + cache).
+6. **Sync the meta in the same change:** READMEs, the Cursor rules (`.cursor/rules/`), MCP
+   tool descriptions, and release guards (`publish.yml`, pinned tool versions). Flag any
+   claim that went stale.
+
+## Definition of Done (per user-facing feature, not per PR)
+
+The Pre-PR rubric above is per *change*. A feature that spans several PRs also needs a
+**feature-level** acceptance gate — the bracket feature became a core release plus four
+reactive dot-releases because each gap (ambiguous dates, missing host-nation flags, a
+dropped `tz` on MCP `get_bracket`) was found by *using* the feature after it was already
+live. Before implementing a user-facing feature, write 3–5 acceptance criteria **from the
+user's point of view** and don't call it done until each holds on a real terminal:
+
+- The output is **unambiguous** to read (e.g. "which calendar day is this match?" across a 3-week span).
+- Every entity renders **consistently with the rest of the product** (host nations show flags like every other team; no static/placeholder leaks; the resultless invariant holds).
+- It behaves across **all timezones, all four locales** (en/es/pt/fr), and **every surface** (CLI text + `--json`, MCP `data` + text, share) — not just en/local/CLI.
+- It **fails closed** (degraded feed → honest TBD/notice, never an invented or stale fact).
+
+Scope these up front so the feature ships whole, not in dot-release pieces.
+
+## Release readiness — run `scripts/release-qa.sh` before tagging
+
+"Test it on a real terminal first" is executable: **`scripts/release-qa.sh`** (`pnpm release:qa`)
+renders *every* user-facing surface against the **live feed, across two timezones and all four
+locales**, and ends with tripwires for known regression classes (bracket shows a calendar date,
+`tz` is actually threaded, disclaimers intact; it SKIPs rather than fails on a degraded/unreachable
+feed, so a network blip never blocks a release). Build, run it, **read the output**, then tag. It
+does not replace the eyeball — its job is to put every surface in front of you so nothing ships
+unseen. (It covers CLI/share rendering; MCP arg-threading is guarded by
+`packages/mcp/test/tools.test.ts` — keep that green too.)
+
+## Release cadence — batch, don't dot-release per fix
+
+Two kinds of release, and only one is urgent:
+
+- **Hotfix-now** — live data *correctness* only (a wrong score/standing *during* a match,
+  or a feed outage rendering as authoritative). Ship immediately.
+- **Everything else** — UX, polish, cosmetics, follow-on sub-features — **batch** onto the
+  working branch and release as a single bump. Stack review fixes for the same feature into the
+  same PR before merge.
+
+Every release carries real toil (a multi-file version bump, and for MCP-affecting changes an MCP
+Registry re-publish). Fewer, fuller releases cut that directly. When unsure, accumulate.
+
+## Don't
+
+- Don't put API keys in client packages — keys live **only** in the gateway.
+- Don't block the statusline hot path on the network — read from the local cache (<150ms).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,26 @@ To cut a release:
 - Account 2FA set to "Authorization and writes" forces an OTP that CI can't supply; trusted
   publishing (OIDC) sidesteps it entirely.
 
+## Commit attribution (all agents)
+
+This repo is worked on by multiple AI coding agents. Commits produced with one are
+**co-authored by the agent and the model** that wrote them, so `git log` (and the GitHub
+contributors view) shows which agent — and which model — did the work. Add a trailer in the
+**last paragraph** of the commit message, and credit the same in the PR body:
+
+```
+Co-Authored-By: <Agent> (<Model>) <agent-no-reply-email>
+```
+
+Use the model **actually in use**, not a hardcoded one. Examples, one per agent (Claude Code
+uses Anthropic's no-reply address; Cursor and Codex follow the same pattern with their own):
+
+```
+Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>
+Co-Authored-By: Cursor (Composer 2.5) <...>
+Co-Authored-By: Codex (GPT 5.5) <...>
+```
+
 ## Conventions
 
 - Shared domain types live in `@claudinho/core` — never duplicate them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# CLAUDE.md
+
+This project uses **AGENTS.md** as the primary agent guide. Read it first:
+
+@AGENTS.md
+
+## Claude Code specifics
+
+- The statusline command must return in **<150ms** and **never** hit the network on the hot path — read from the local micro-cache.
+- Local MCP dev loop:
+  ```bash
+  pnpm -F @claudinho/mcp build
+  claude mcp add claudinho-dev -- node packages/mcp/dist/index.js
+  ```
+- When changing shared types, update `@claudinho/core` and run `pnpm -r typecheck` before committing.
+- Run `pnpm lint` (Biome) before committing; CI gates on it. The setup is lint-only (no formatter) — keep style consistent with the surrounding code.
+- **Before declaring any change "done," run the "Pre-PR self-review" rubric in `AGENTS.md`** — verify external API shapes against a *real* response (fixtures included); apply the change to every surface (CLI text **and** `--json`, MCP `data` **and** text, READMEs); audit against the Hard Constraints (existing code too); do an adversarial failure-mode pass (fail-closed; never cache transient errors); and bound default-on latency. For money/legal/external-API changes, do an independent reviewer pass and self-classify findings **P1/P2/P3**.
+- **After any push to a branch with CI, always watch the run and confirm it's green** (`gh run watch <id> --exit-status`); report the per-job result. Don't consider a push "done" until CI passes.


### PR DESCRIPTION
## Why

We already publish `.cursor/rules/*` as contributor-facing guardrails. This does the same for the cross-agent **`AGENTS.md`** (the [agents.md](https://agents.md) standard) and the Claude-specific **`CLAUDE.md`** — clean, worked examples that also guide anyone who clones the repo.

## What changed

- **`AGENTS.md`** (now tracked) — curated to the public-safe engineering guide: what this is, stack, layout, commands, release mechanism (trusted-publishing/OIDC + the hard-won lessons), conventions, legal hard-constraints, the Pre-PR self-review rubric, Definition of Done, release-qa readiness, and release cadence. The planned **Gateway** is now marked `(planned, not yet built)` in Stack (it was reading as current).
- **`CLAUDE.md`** (now tracked) — Claude Code specifics (statusline budget, MCP dev loop, the review rubric pointer, watch-CI), importing `@AGENTS.md`.
- **`.gitignore`** — now *tracks* `AGENTS.md`/`CLAUDE.md`; ignores a new `CLAUDE.local.md`.

## What stays private

The candid maintainer content — version-by-version release log, incident post-mortems, operational/strategy notes — moved to a **gitignored** `docs/AGENTS.internal.md`, auto-loaded locally via a **gitignored** `CLAUDE.local.md` (`@`-import). On a fresh public clone those files simply don't exist and the import silently skips — no dangling reference.

**Boundary: content, not file-type.** Engineering process → public; candid history / strategy / toil → private. Nothing was lost; it moved.

## Test plan
- [x] `git check-ignore`: `AGENTS.md`/`CLAUDE.md` trackable; `CLAUDE.local.md` + `docs/AGENTS.internal.md` ignored
- [x] Leak scan: no private-doc refs / incident / strategy content in the public files
- [x] PR diff contains only the 3 public files

---
🤖 Co-authored with [Claude Code](https://claude.com/claude-code) (Opus 4.8).