### PR TITLE
docs: align release-discipline with public AGENTS/CLAUDE guides

### DIFF
--- a/.cursor/rules/release-discipline.mdc
+++ b/.cursor/rules/release-discipline.mdc
@@ -9,13 +9,16 @@ alwaysApply: true
 
 - **One user-facing feature → one minor.** Stack review fixes (tz, dates, guards) into the **same PR** before merge when they belong to the same feature.
 - Do **not** tag npm until CI is green **and** `pnpm release:qa` passes (tripwires at the end must be 0 failed).
-- Before tagging: `git diff main` must not include accidental internal docs (`docs/`), `.env`, or agent guides (`AGENTS.md`/`CLAUDE.md`).
+- Before tagging: `git diff main` must not include accidental private paths (`docs/`, `CLAUDE.local.md`, `.env`).
 
-## Gitignored paths (never publish)
+## Public vs private docs
 
-`docs/`, `AGENTS.md`, and `CLAUDE.md` are **local-only**.
+**Tracked (public engineering guides):** `AGENTS.md`, `CLAUDE.md`, `.cursor/rules/`, README, MCP tool descriptions.
 
-- Doc reviews → update **tracked** surfaces: `README`, MCP tool descriptions, `.cursor/rules/`.
+**Gitignored (maintainer-local):** `docs/` (e.g. `docs/AGENTS.internal.md` notebook), `CLAUDE.local.md`.
+
+- Engineering process → update the **public** guides above.
+- Candid history, strategy, or release post-mortems → `docs/` notebook only.
 - **Never** add `!docs/…` exceptions to `.gitignore` without explicit maintainer approval.
 
 ## Bracket / live-formatting ship checklist

--- a/.cursor/rules/release-discipline.mdc
+++ b/.cursor/rules/release-discipline.mdc
@@ -11,6 +11,10 @@ alwaysApply: true
 - Do **not** tag npm until CI is green **and** `pnpm release:qa` passes (tripwires at the end must be 0 failed).
 - Before tagging: `git diff main` must not include accidental private paths (`docs/`, `CLAUDE.local.md`, `.env`).
 
+## Commit attribution
+
+Every commit produced with an AI agent: follow **`AGENTS.md` § Commit attribution** — trailer names the agent **and** model in use (e.g. `Co-Authored-By: Cursor (Composer 2.5) <cursoragent@cursor.com>`).
+
 ## Public vs private docs
 
 **Tracked (public engineering guides):** `AGENTS.md`, `CLAUDE.md`, `.cursor/rules/`, README, MCP tool descriptions.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,7 +28,7 @@
 
 ### Release / docs
 
-- [ ] No gitignored paths committed (`docs/`, `AGENTS.md`, `CLAUDE.md`) — update README / MCP descriptions / cursor rules instead
+- [ ] No **private** paths committed (`docs/`, `CLAUDE.local.md`, `.env`) — engineering updates go in `AGENTS.md`, `CLAUDE.md`, `.cursor/rules/`, README, or MCP descriptions
 - [ ] Review fixes for the same feature batched in this PR (avoid follow-up patch releases)
 
 ### Assumptions


### PR DESCRIPTION
## Summary
- Update `release-discipline.mdc` to reflect #39's doc boundary: `AGENTS.md` / `CLAUDE.md` are public; `docs/` and `CLAUDE.local.md` stay private.
- Fix stale PR template checkbox that still listed agent guides as gitignored.

## Test plan
- [x] Docs-only change — no code paths affected


Made with [Cursor](https://cursor.com)