### PR TITLE
docs: add Codex agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Co-Authored-By: Cursor (Composer 2.5) <...>
 Co-Authored-By: Codex (GPT-5) <noreply@openai.com>
 ```
 
-## Codex / GPT specifics
+## Reviewing PRs (all agents)
 
 - For PR reviews, first verify the local checkout matches the PR head before running gates:
   `gh pr view <n> --json headRefOid,headRefName` and `git rev-parse HEAD`. If they differ,
@@ -96,16 +96,14 @@ Co-Authored-By: Codex (GPT-5) <noreply@openai.com>
   that plainly and list the checks run plus any residual risk.
 - Do not treat a previous review, memory, or local branch name as current truth. Re-check the PR
   SHA, merge state, and CI status at the end of the review.
-- Use the full local gate before calling code merge-ready:
-  `pnpm -r build && pnpm -r typecheck && pnpm -r test && pnpm lint`. For user-facing changes,
-  also run `pnpm release:qa` after build and read the rendered output.
-- For live data, external APIs, legal/money-adjacent features, MCP contracts, or formatter changes,
-  do an adversarial pass over malformed data, degraded feeds, timeouts, missing fields,
-  timezone/locale/flags args, and every output surface.
-- Preserve the public/private boundary. Update tracked public surfaces (`README`, package READMEs,
-  MCP descriptions, `.cursor/rules/`, `AGENTS.md`, `CLAUDE.md`) and never commit `docs/`,
-  `CLAUDE.local.md`, `.env`, or private maintainer notes.
-- Use the actual model in commit trailers; do not copy a stale example if the runtime model changed.
+
+## Codex / GPT specifics
+
+- Codex has no separate sidecar guide in this repo; `AGENTS.md` is its source of truth. Follow
+  the shared sections here: "Reviewing PRs", "Pre-PR self-review", "Release readiness", and
+  "Commit attribution".
+- If Codex makes a commit, use the actual GPT model in the `Co-Authored-By` trailer; the example
+  above is illustrative, not a hardcoded model name.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ uses Anthropic's no-reply address; Cursor and Codex follow the same pattern with
 ```
 Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>
 Co-Authored-By: Cursor (Composer 2.5) <...>
-Co-Authored-By: Codex (GPT-5) <...>
+Co-Authored-By: Codex (GPT-5) <noreply@openai.com>
 ```
 
 ## Codex / GPT specifics

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,8 +83,29 @@ uses Anthropic's no-reply address; Cursor and Codex follow the same pattern with
 ```
 Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>
 Co-Authored-By: Cursor (Composer 2.5) <...>
-Co-Authored-By: Codex (GPT 5.5) <...>
+Co-Authored-By: Codex (GPT-5) <...>
 ```
+
+## Codex / GPT specifics
+
+- For PR reviews, first verify the local checkout matches the PR head before running gates:
+  `gh pr view <n> --json headRefOid,headRefName` and `git rev-parse HEAD`. If they differ,
+  check out or fast-forward the PR branch before reviewing.
+- Review-only tasks are read-only unless the user explicitly asks for fixes. Lead with findings,
+  classify them P1/P2/P3, and include tight file/line references. If there are no findings, say
+  that plainly and list the checks run plus any residual risk.
+- Do not treat a previous review, memory, or local branch name as current truth. Re-check the PR
+  SHA, merge state, and CI status at the end of the review.
+- Use the full local gate before calling code merge-ready:
+  `pnpm -r build && pnpm -r typecheck && pnpm -r test && pnpm lint`. For user-facing changes,
+  also run `pnpm release:qa` after build and read the rendered output.
+- For live data, external APIs, legal/money-adjacent features, MCP contracts, or formatter changes,
+  do an adversarial pass over malformed data, degraded feeds, timeouts, missing fields,
+  timezone/locale/flags args, and every output surface.
+- Preserve the public/private boundary. Update tracked public surfaces (`README`, package READMEs,
+  MCP descriptions, `.cursor/rules/`, `AGENTS.md`, `CLAUDE.md`) and never commit `docs/`,
+  `CLAUDE.local.md`, `.env`, or private maintainer notes.
+- Use the actual model in commit trailers; do not copy a stale example if the runtime model changed.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary
- add a Codex / GPT specifics section to AGENTS.md
- document PR checkout verification, read-only review behavior, final SHA/CI re-checks, release gates, adversarial checks, and public/private doc boundaries
- update the Codex commit-attribution example to GPT-5

## Test plan
- [x] git diff --cached --check

Co-Authored-By: Codex (GPT-5) <noreply@openai.com>