### PR TITLE
fix(core): confirm bracket group slots when the group is fully played

### DIFF
--- a/.cursor/rules/bundle-bracket-pr.mdc
+++ b/.cursor/rules/bundle-bracket-pr.mdc
@@ -20,7 +20,7 @@ Before marking a data-heavy feature merge-ready, run **`pnpm -r build && pnpm -r
 
 - Advance winners from **score OR `winnerCode`** (ESPN `competitor.winner` for penalties).
 - Always test FT draw + `winnerCode` — routine in knockouts.
-- Group slots project from live standings once **≥1 match played** (`hasGroupStarted`); **`confirmed`** when all four teams have played 3 (`isGroupComplete`); **`(proj.)`** only mid-group. TBD at 0 games or when standings are degraded.
+- Group slots project from live standings once **≥1 match played** (`hasGroupStarted`); **`confirmed`** when every team has played a full round-robin (`played >= n - 1` for `n` teams); **`(proj.)`** only mid-group. TBD at 0 games or when standings are degraded.
 
 ## Topology indexing
 
@@ -48,7 +48,7 @@ After `pnpm -r build`, run **`pnpm release:qa`** (`scripts/release-qa.sh`). Eyeb
 | Bundle-only bracket | No real flags in R32+ slots |
 | Group at 0 games played | Slots stay `tbd`, no `(proj.)` |
 | Group at 2/3 played, standings live | Leaders show flags + `(proj.)` |
-| Group fully played (3/3 each) | Winner + runner-up `confirmed`, no `(proj.)` |
+| Group fully played (round-robin complete) | Winner + runner-up `confirmed`, no `(proj.)` |
 | `toolGetBracket` `tz: UTC` vs `America/Mexico_City` | Calendar date/time differs on cross-midnight kickoff |
 | Knockout kickoffs span >1 week | Output includes month + day (not weekday-only) |
 | `formatShareBracket` social + compact | Same date format as CLI list |

--- a/.cursor/rules/bundle-bracket-pr.mdc
+++ b/.cursor/rules/bundle-bracket-pr.mdc
@@ -20,7 +20,7 @@ Before marking a data-heavy feature merge-ready, run **`pnpm -r build && pnpm -r
 
 - Advance winners from **score OR `winnerCode`** (ESPN `competitor.winner` for penalties).
 - Always test FT draw + `winnerCode` — routine in knockouts.
-- Group slots project from live standings once **≥1 match played** in the group (`hasGroupStarted`); stay TBD at 0 games or when standings are degraded. Mark projected slots `(proj.)`.
+- Group slots project from live standings once **≥1 match played** (`hasGroupStarted`); **`confirmed`** when all four teams have played 3 (`isGroupComplete`); **`(proj.)`** only mid-group. TBD at 0 games or when standings are degraded.
 
 ## Topology indexing
 
@@ -48,6 +48,7 @@ After `pnpm -r build`, run **`pnpm release:qa`** (`scripts/release-qa.sh`). Eyeb
 | Bundle-only bracket | No real flags in R32+ slots |
 | Group at 0 games played | Slots stay `tbd`, no `(proj.)` |
 | Group at 2/3 played, standings live | Leaders show flags + `(proj.)` |
+| Group fully played (3/3 each) | Winner + runner-up `confirmed`, no `(proj.)` |
 | `toolGetBracket` `tz: UTC` vs `America/Mexico_City` | Calendar date/time differs on cross-midnight kickoff |
 | Knockout kickoffs span >1 week | Output includes month + day (not weekday-only) |
 | `formatShareBracket` social + compact | Same date format as CLI list |

--- a/packages/core/src/bracket/resolve.ts
+++ b/packages/core/src/bracket/resolve.ts
@@ -36,6 +36,12 @@ function hasGroupStarted(group: string, tables: GroupStandings[]): boolean {
   return table.rows.some((r) => r.played > 0);
 }
 
+function isGroupComplete(group: string, tables: GroupStandings[]): boolean {
+  const table = tables.find((t) => t.group === group);
+  if (!table?.rows.length || table.rows.length !== 4) return false;
+  return table.rows.every((r) => r.played >= 3);
+}
+
 function resolveWinner(match: Match): Team | undefined {
   if (!isFinished(match.status)) return undefined;
   if (match.winnerCode) {
@@ -89,7 +95,12 @@ function resolveSlot(ref: SlotRef, ctx: ResolveContext): ResolvedParticipant {
     case 'group': {
       if (!ctx.standingsDegraded && hasGroupStarted(ref.group, ctx.tables)) {
         const team = teamFromStandings(ref.group, ref.position, ctx.tables);
-        if (team) return participant(team, 'projected');
+        if (team) {
+          const status: SlotStatus = isGroupComplete(ref.group, ctx.tables)
+            ? 'confirmed'
+            : 'projected';
+          return participant(team, status);
+        }
       }
       const label =
         ref.position === 1
@@ -129,8 +140,8 @@ function resolveSlot(ref: SlotRef, ctx: ResolveContext): ResolvedParticipant {
 
 /**
  * Resolve the bundled topology against merged knockout matches and standings.
- * Group slots project from live standings once a group has started; winner/loser slots
- * require a confirmed FT result on the source match.
+ * Group slots project from live standings once a group has started; confirmed when
+ * the group is fully played. Winner/loser slots require a confirmed FT result.
  */
 export function buildBracketView(
   topology: BracketTopology,

--- a/packages/core/src/bracket/resolve.ts
+++ b/packages/core/src/bracket/resolve.ts
@@ -36,10 +36,21 @@ function hasGroupStarted(group: string, tables: GroupStandings[]): boolean {
   return table.rows.some((r) => r.played > 0);
 }
 
+/** Round-robin group stage: each team plays every other team once. */
+function matchesPerTeamInGroup(teamCount: number): number {
+  return Math.max(0, teamCount - 1);
+}
+
+/** True when every team in the table has played a full round-robin. */
+export function isGroupStandingsComplete(table: GroupStandings | undefined): boolean {
+  const n = table?.rows.length ?? 0;
+  if (n < 2) return false;
+  const required = matchesPerTeamInGroup(n);
+  return table!.rows.every((r) => r.played >= required);
+}
+
 function isGroupComplete(group: string, tables: GroupStandings[]): boolean {
-  const table = tables.find((t) => t.group === group);
-  if (!table?.rows.length || table.rows.length !== 4) return false;
-  return table.rows.every((r) => r.played >= 3);
+  return isGroupStandingsComplete(tables.find((t) => t.group === group));
 }
 
 function resolveWinner(match: Match): Team | undefined {

--- a/packages/core/test/bracket-resolve.test.ts
+++ b/packages/core/test/bracket-resolve.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildBracketView } from '../src/bracket/resolve';
+import { buildBracketView, isGroupStandingsComplete } from '../src/bracket/resolve';
 import { loadBracketTopology } from '../src/bracket/topology';
 import { allFixtures } from '../src/schedule';
 import type { Match } from '../src/types';
@@ -158,6 +158,27 @@ describe('buildBracketView', () => {
     const secondPlace = r32.matches.find((m) => m.index === 1)?.home;
     expect(secondPlace?.code).toBe('RSA');
     expect(secondPlace?.status).toBe('confirmed');
+  });
+
+  it('confirms group slots when a non-4-team group finishes round-robin', () => {
+    const rows = Array.from({ length: 8 }, (_, i) => ({
+      team: { code: `T${i}`, name: `Team ${i}`, flag: '🏳️' },
+      played: 7,
+      won: i === 0 ? 7 : 0,
+      drawn: 0,
+      lost: i === 0 ? 0 : 7,
+      goalsFor: i === 0 ? 14 : 0,
+      goalsAgainst: i === 0 ? 0 : 2,
+      goalDiff: i === 0 ? 14 : -2,
+      points: i === 0 ? 21 : 0,
+    }));
+    const tables: GroupStandings[] = [{ group: 'Z', rows }];
+    expect(isGroupStandingsComplete(tables[0])).toBe(true);
+    const incomplete: GroupStandings = {
+      group: 'Z',
+      rows: rows.map((r, i) => ({ ...r, played: i === 0 ? 7 : 6 })),
+    };
+    expect(isGroupStandingsComplete(incomplete)).toBe(false);
   });
 
   it('projects the current group leader mid-tournament from live standings', () => {

--- a/packages/core/test/bracket-resolve.test.ts
+++ b/packages/core/test/bracket-resolve.test.ts
@@ -101,7 +101,7 @@ describe('buildBracketView', () => {
     });
   });
 
-  it('projects a host group-winner slot when the group is fully played', () => {
+  it('confirms a host group-winner slot when the group is fully played', () => {
     const tables: GroupStandings[] = [
       {
         group: 'A',
@@ -119,10 +119,10 @@ describe('buildBracketView', () => {
       ?.matches.find((m) => m.matchId === '760491')?.home;
     expect(mexicoSlot?.code).toBe('MEX');
     expect(mexicoSlot?.flag).toBe('🇲🇽');
-    expect(mexicoSlot?.status).toBe('projected');
+    expect(mexicoSlot?.status).toBe('confirmed');
   });
 
-  it('projects a group slot from standings when the group is fully played', () => {
+  it('confirms group winner and runner-up when the group is fully played', () => {
     const tables: GroupStandings[] = [
       {
         group: 'C',
@@ -138,7 +138,26 @@ describe('buildBracketView', () => {
     const r32 = view.stages.find((s) => s.stage === 'R32')!;
     const groupWinner = r32.matches.find((m) => m.index === 2)?.home;
     expect(groupWinner?.code).toBe('GER');
-    expect(groupWinner?.status).toBe('projected');
+    expect(groupWinner?.status).toBe('confirmed');
+  });
+
+  it('confirms group runner-up when the group is fully played', () => {
+    const tables: GroupStandings[] = [
+      {
+        group: 'A',
+        rows: [
+          { team: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' }, played: 3, won: 3, drawn: 0, lost: 0, goalsFor: 5, goalsAgainst: 1, goalDiff: 4, points: 9 },
+          { team: { code: 'RSA', name: 'South Africa', flag: '🇿🇦' }, played: 3, won: 1, drawn: 1, lost: 1, goalsFor: 2, goalsAgainst: 3, goalDiff: -1, points: 4 },
+          { team: { code: 'KOR', name: 'South Korea', flag: '🇰🇷' }, played: 3, won: 1, drawn: 0, lost: 2, goalsFor: 2, goalsAgainst: 4, goalDiff: -2, points: 3 },
+          { team: { code: 'CZE', name: 'Czechia', flag: '🇨🇿' }, played: 3, won: 0, drawn: 1, lost: 2, goalsFor: 2, goalsAgainst: 3, goalDiff: -1, points: 1 },
+        ],
+      },
+    ];
+    const view = buildBracketView(topology, baseKo, tables, false, false);
+    const r32 = view.stages.find((s) => s.stage === 'R32')!;
+    const secondPlace = r32.matches.find((m) => m.index === 1)?.home;
+    expect(secondPlace?.code).toBe('RSA');
+    expect(secondPlace?.status).toBe('confirmed');
   });
 
   it('projects the current group leader mid-tournament from live standings', () => {


### PR DESCRIPTION
## Summary
- Restore `isGroupComplete` so group-winner and runner-up slots are **`confirmed`** (no `(proj.)`) once all four teams have played 3 matches.
- Mid-group standings still show `(proj.)`; 0 games stays `tbd`.
- Fixes regression introduced in #35 where every group slot was always `projected`.

## Example
```
🇿🇦 South Africa vs Canada 🇨🇦     ← Groups A/B complete
🇧🇷 Brazil vs Japan (proj.) 🇯🇵   ← C complete, F still in play
🇲🇽 Mexico vs 3rd …                ← A winner confirmed
```

## Test plan
- [x] `pnpm -r build && pnpm -r typecheck && pnpm -r test`
- [x] `node packages/cli/dist/index.js bracket` — A/B/C finishers confirmed; D–L still `(proj.)` at 2/3 played

Co-Authored-By: Cursor (Composer 2.5) <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)