### PR TITLE
fix(core): resolve live third-place bracket slots

### DIFF
--- a/packages/core/src/bracket/resolve.ts
+++ b/packages/core/src/bracket/resolve.ts
@@ -92,6 +92,11 @@ function tbd(label: string): ResolvedParticipant {
   return { label, flag: '🏳️', status: 'tbd' };
 }
 
+function confirmedLiveParticipant(team: Team | undefined): ResolvedParticipant | undefined {
+  if (!team || team.flag === '🏳️') return undefined;
+  return participant(team, 'confirmed');
+}
+
 function winnerLabel(ctx: ResolveContext, stage: string, index: number): string {
   return t(ctx.lang, 'bracket.slot.winner', {
     stage: stageLabelI18n(ctx.lang, stage),
@@ -99,11 +104,19 @@ function winnerLabel(ctx: ResolveContext, stage: string, index: number): string 
   });
 }
 
-function resolveSlot(ref: SlotRef, ctx: ResolveContext): ResolvedParticipant {
+function resolveSlot(
+  ref: SlotRef,
+  ctx: ResolveContext,
+  liveTeam?: Team,
+): ResolvedParticipant {
+  const liveParticipant = confirmedLiveParticipant(liveTeam);
+
   switch (ref.kind) {
     case 'seed':
+      if (liveParticipant) return liveParticipant;
       return tbd(ref.label);
     case 'group': {
+      if (liveParticipant) return liveParticipant;
       if (!ctx.standingsDegraded && hasGroupStarted(ref.group, ctx.tables)) {
         const team = teamFromStandings(ref.group, ref.position, ctx.tables);
         if (team) {
@@ -120,6 +133,7 @@ function resolveSlot(ref: SlotRef, ctx: ResolveContext): ResolvedParticipant {
       return tbd(label);
     }
     case 'third':
+      if (liveParticipant) return liveParticipant;
       return tbd(t(ctx.lang, 'bracket.slot.third', { groups: ref.groups.join('/') }));
     case 'winner': {
       const node = ctx.nodesByKey.get(matchKey(ref.stage, ref.index));
@@ -128,6 +142,7 @@ function resolveSlot(ref: SlotRef, ctx: ResolveContext): ResolvedParticipant {
         const winner = resolveWinner(match);
         if (winner) return participant(winner, 'confirmed');
       }
+      if (liveParticipant) return liveParticipant;
       return tbd(winnerLabel(ctx, ref.stage, ref.index));
     }
     case 'loser': {
@@ -137,6 +152,7 @@ function resolveSlot(ref: SlotRef, ctx: ResolveContext): ResolvedParticipant {
         const loser = resolveLoser(match);
         if (loser) return participant(loser, 'confirmed');
       }
+      if (liveParticipant) return liveParticipant;
       return tbd(
         t(ctx.lang, 'bracket.slot.loser', {
           stage: stageLabelI18n(ctx.lang, ref.stage),
@@ -192,8 +208,8 @@ export function buildBracketView(
         stage: node.stage,
         index: node.index,
         kickoff: match.kickoff,
-        home: resolveSlot(node.home, ctx),
-        away: resolveSlot(node.away, ctx),
+        home: resolveSlot(node.home, ctx, match.home),
+        away: resolveSlot(node.away, ctx, match.away),
         match,
       };
     });

--- a/packages/core/test/bracket-resolve.test.ts
+++ b/packages/core/test/bracket-resolve.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { buildBracketView, isGroupStandingsComplete } from '../src/bracket/resolve';
 import { loadBracketTopology } from '../src/bracket/topology';
 import { allFixtures } from '../src/schedule';
-import type { Match } from '../src/types';
+import type { Match, Team } from '../src/types';
 import type { GroupStandings } from '../src/standings';
+
+function team(code: string, name: string, flag: string): Team {
+  return { code, name, flag };
+}
 
 function fx(
   id: string,
@@ -99,6 +103,50 @@ describe('buildBracketView', () => {
       position: 1,
       group: 'J',
     });
+  });
+
+  it('confirms a resolved live participant in a third-place slot', () => {
+    const node = topology.matches.find((n) => n.matchId === '760489')!;
+    expect(node.away).toEqual({
+      kind: 'third',
+      groups: ['A', 'B', 'C', 'D', 'F'],
+    });
+    const merged = baseKo.map((m) =>
+      m.id === node.matchId
+        ? {
+            ...m,
+            home: team('GER', 'Germany', '🇩🇪'),
+            away: team('PAR', 'Paraguay', '🇵🇾'),
+          }
+        : m,
+    );
+
+    const view = buildBracketView(topology, merged, [], true, false);
+    const match = view.stages
+      .find((s) => s.stage === 'R32')
+      ?.matches.find((m) => m.matchId === node.matchId);
+    expect(match?.home).toMatchObject({ code: 'GER', label: 'Germany', status: 'confirmed' });
+    expect(match?.away).toMatchObject({ code: 'PAR', label: 'Paraguay', status: 'confirmed' });
+  });
+
+  it('keeps third-place slots unresolved when the live event still has a placeholder', () => {
+    const node = topology.matches.find((n) => n.matchId === '760491')!;
+    const merged = baseKo.map((m) =>
+      m.id === node.matchId
+        ? {
+            ...m,
+            home: team('MEX', 'Mexico', '🇲🇽'),
+            away: team('3RD', 'Third Place Group C/E/F/H/I', '🏳️'),
+          }
+        : m,
+    );
+
+    const view = buildBracketView(topology, merged, [], true, false);
+    const match = view.stages
+      .find((s) => s.stage === 'R32')
+      ?.matches.find((m) => m.matchId === node.matchId);
+    expect(match?.home).toMatchObject({ code: 'MEX', label: 'Mexico', status: 'confirmed' });
+    expect(match?.away).toMatchObject({ label: '3rd (C/E/F/H/I)', status: 'tbd' });
   });
 
   it('confirms a host group-winner slot when the group is fully played', () => {


### PR DESCRIPTION
## Summary
- resolve real live knockout participants when ESPN replaces third-place placeholders with actual teams
- keep composite third-place placeholders unresolved when the live event still carries a placeholder team
- add regression coverage for a resolved `Germany vs Paraguay`-style third-place slot and an unresolved placeholder slot

## Live verification
Before this fix, `claudinho bracket R32` rendered:

```text
🇩🇪 Germany vs 3rd (A/B/C/D/F)
```

After this fix, live output renders:

```text
🇩🇪 Germany vs Paraguay 🇵🇾
🇫🇷 France vs Sweden 🇸🇪
🇺🇸 United States vs Bosnia-Herzegovina 🇧🇦
```

## Checks
- `pnpm -F @claudinho/core test -- bracket-resolve.test.ts`
- `pnpm -F @claudinho/cli test -- bracket.test.ts share.test.ts`
- `pnpm -F @claudinho/mcp test -- tools.test.ts share.test.ts`
- `pnpm -r build`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm lint`
- `pnpm release:qa` (`4 passed · 0 failed · 0 skipped`)

Co-Authored-By: Codex (GPT-5) <noreply@openai.com>
