### PR TITLE
fix(core): live-resolve a team's next fixture across the knockout phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ _Planned (not shipped yet):_ a desktop notifier and an AI pundit with a public a
 
 **Do I need an API key or account?** No. Nothing to sign up for; `npx` and done.
 
-**Does it work offline?** The schedule, `next`, group skeletons, and knockout bracket structure do — all 104 fixtures are bundled. Only live scores hit the network.
+**Does it work offline?** The bundled data does — the full schedule, group fixtures, and the knockout bracket *structure* (all 104 fixtures ship bundled, no key). Anything *live* hits the network: scores, group standings, and a team's resolved knockout opponent (`next` once the draw fills in).
 
 **Where does the data come from?** Live scores from ESPN's public scoreboard (attributed in output as `Live data: ESPN`); market signals from Polymarket public data. Rate limits respected.
 

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -25,7 +25,6 @@ import {
   marketRelevant,
   matchFlavor,
   matchLocation,
-  nextFixtureForTeam,
   resolveCompetition,
   resolveMarketSource,
   scoreline,
@@ -50,6 +49,7 @@ import {
 import {
   getLiveMatches,
   getMatchesForDate,
+  getNextFixtureForTeam,
   getStandings,
   getBracket,
   makeAdapter,
@@ -291,13 +291,21 @@ export async function cmdLive(ctx: Ctx): Promise<void> {
 }
 
 /** `claudinho next [team]` (team defaults to CLAUDINHO_TEAM) */
-export async function cmdNext(team: string | undefined, { cfg, t, now }: Ctx): Promise<void> {
+export async function cmdNext(team: string | undefined, ctx: Ctx): Promise<void> {
+  const { cfg, t, now } = ctx;
   precheck(cfg, t);
   const code = resolveTeamArg(team, 'Usage: claudinho next <team> (or set CLAUDINHO_TEAM)');
-  const fixture = nextFixtureForTeam(code, { from: now ?? new Date() });
+  // Live-resolved: the bundled knockout slots are resultless placeholders, so a
+  // static lookup goes blind once a team's group games pass — overlay the live
+  // knockout window so a confirmed R32+ tie (e.g. MEX vs ECU) surfaces here too.
+  const { fixture, degraded, source } = await getNextFixtureForTeam(
+    adapterFor(ctx),
+    code,
+    now ?? new Date(),
+  );
 
   if (cfg.json) {
-    emitJson({ team: code, fixture: fixture ?? null });
+    emitJson({ team: code, fixture: fixture ?? null, degraded, source: source ?? null });
     return;
   }
 
@@ -305,7 +313,9 @@ export async function cmdNext(team: string | undefined, { cfg, t, now }: Ctx): P
   const flags = flagsEnabled();
   out();
   if (!fixture) {
-    out(c.dim('  ' + t('next.none', { team: code })));
+    // Fail-closed honesty: a feed outage must read as "couldn't reach the
+    // provider", never as "this team has no upcoming fixture" (= eliminated).
+    out(c.dim('  ' + (degraded ? t('live.degraded') : t('next.none', { team: code }))));
     out();
     out(disclaimer(t, c));
     return;
@@ -322,6 +332,10 @@ export async function cmdNext(team: string | undefined, { cfg, t, now }: Ctx): P
       ),
   );
   out();
+  // Attribute the provider when the live overlay resolved the fixture (a
+  // knockout tie); a static group fixture carries no source.
+  const src = dataSource(source, cfg.lang, c);
+  if (src) out(src);
   out(disclaimer(t, c));
 }
 
@@ -1108,7 +1122,13 @@ export async function cmdShare(
   if (target === 'next') {
     precheck(cfg, t);
     const code = resolveTeamArg(team, 'Usage: claudinho share next <team> (or set CLAUDINHO_TEAM)');
-    const fixture = nextFixtureForTeam(code, { from: ctx.now ?? new Date() });
+    // Live-resolved (see cmdNext): overlay the knockout window so a confirmed
+    // R32+ tie pastes here too, not just group games.
+    const { fixture, degraded, source } = await getNextFixtureForTeam(
+      adapterFor(ctx),
+      code,
+      ctx.now ?? new Date(),
+    );
     const matches = fixture ? [fixture] : [];
     const signals = await reliableShareSignals(ctx, matches);
     const teamName = fixture
@@ -1126,7 +1146,14 @@ export async function cmdShare(
           title: `Next up for ${teamName}`,
           matches,
           marketSignals: signals,
-          emptyNote: `No upcoming fixture found for ${code}.`,
+          // Attribute the provider when the overlay resolved the tie (knockout);
+          // undefined for a static group fixture — parity with CLI `next`.
+          source,
+          degraded,
+          // Fail-closed: an outage must never paste as "no fixture" (eliminated).
+          emptyNote: degraded
+            ? `Couldn't reach the data provider — no upcoming fixture confirmed for ${code}.`
+            : `No upcoming fixture found for ${code}.`,
           installLine: `npx @claudinho/cli next ${code}`,
           tz: cfg.tz,
           locale: cfg.lang,

--- a/packages/cli/src/data.ts
+++ b/packages/cli/src/data.ts
@@ -10,7 +10,9 @@ export {
   getLiveMatches,
   getStandings,
   getBracket,
+  getNextFixtureForTeam,
   type LiveResult,
+  type NextFixtureResult,
   type StandingsResult,
   type BracketResult,
 } from '@claudinho/core';

--- a/packages/cli/test/next-knockout.test.ts
+++ b/packages/cli/test/next-knockout.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Match, ProviderAdapter } from '@claudinho/core';
+import { cmdNext, cmdShare } from '../src/commands';
+import type { CliConfig } from '../src/config';
+import { makeT } from '../src/i18n';
+
+/** A confirmed R32 tie ESPN has filed over the bundled placeholder slot. */
+function r32MexEcu(): Match {
+  return {
+    id: '760486',
+    stage: 'R32',
+    kickoff: '2026-06-30T18:00Z',
+    venue: 'SoFi Stadium',
+    home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+    away: { code: 'ECU', name: 'Ecuador', flag: '🇪🇨' },
+    status: 'SCHEDULED',
+    updatedAt: '2026-06-28T00:00Z',
+  };
+}
+
+function windowAdapter(window: Match[], opts: { throws?: boolean } = {}): ProviderAdapter {
+  return {
+    name: 'espn',
+    capabilities: { push: false, latencyHintSec: 0 },
+    async fetchByDate() {
+      if (opts.throws) throw new Error('down');
+      return [];
+    },
+    async fetchLive() {
+      if (opts.throws) throw new Error('down');
+      return [];
+    },
+    async fetchWindow() {
+      if (opts.throws) throw new Error('down');
+      return window;
+    },
+  };
+}
+
+function cfg(over: Partial<CliConfig> = {}): CliConfig {
+  return {
+    lang: 'en',
+    tz: 'UTC',
+    json: true,
+    color: false,
+    source: 'espn',
+    flavor: 'off',
+    markets: false,
+    ...over,
+  };
+}
+
+// Group stage is done on the knockout days, so a static lookup is blind.
+const KNOCKOUT_NOW = new Date('2026-06-28T12:00:00Z');
+
+const outSpy = vi.spyOn(process.stdout, 'write');
+let writes: string[] = [];
+beforeEach(() => {
+  writes = [];
+  outSpy.mockImplementation((c: unknown) => {
+    writes.push(String(c));
+    return true;
+  });
+});
+afterEach(() => outSpy.mockReset());
+const json = () => JSON.parse(writes.join(''));
+const text = () => writes.join('');
+
+describe('cmdNext — live-resolved knockout fixture', () => {
+  it('resolves a confirmed R32 tie from the live overlay (--json)', async () => {
+    await cmdNext('MEX', {
+      cfg: cfg(),
+      t: makeT('en'),
+      adapter: windowAdapter([r32MexEcu()]),
+      now: KNOCKOUT_NOW,
+    });
+    const data = json() as { team: string; fixture: Match | null; degraded: boolean; source: string | null };
+    expect(data.team).toBe('MEX');
+    expect(data.fixture?.away.code).toBe('ECU');
+    expect(data.degraded).toBe(false);
+    expect(data.source).toBe('espn'); // live overlay served it → attributed
+  });
+
+  it('renders the tie + provider attribution in text mode', async () => {
+    await cmdNext('MEX', {
+      cfg: cfg({ json: false }),
+      t: makeT('en'),
+      adapter: windowAdapter([r32MexEcu()]),
+      now: KNOCKOUT_NOW,
+    });
+    const t = text();
+    expect(t).toContain('Mexico');
+    expect(t).toContain('Ecuador');
+    expect(t).toContain('Round of 32');
+    expect(t).toContain('Live data: ESPN');
+  });
+
+  it('fails closed on a feed outage: degraded, no invented pairing (--json)', async () => {
+    await cmdNext('MEX', {
+      cfg: cfg(),
+      t: makeT('en'),
+      adapter: windowAdapter([], { throws: true }),
+      now: KNOCKOUT_NOW,
+    });
+    const data = json() as { fixture: Match | null; degraded: boolean };
+    expect(data.degraded).toBe(true);
+    expect(data.fixture).toBeNull();
+  });
+
+  it('feed outage reads as "couldn\'t reach the provider", not "no upcoming fixture" (text)', async () => {
+    await cmdNext('MEX', {
+      cfg: cfg({ json: false }),
+      t: makeT('en'),
+      adapter: windowAdapter([], { throws: true }),
+      now: KNOCKOUT_NOW,
+    });
+    const t = text();
+    expect(t).toContain("couldn't reach the data provider");
+    expect(t).not.toContain('No upcoming fixture found');
+  });
+});
+
+describe('cmdShare next — live-resolved knockout fixture', () => {
+  it('pastes the resolved tie and attributes the provider (--json)', async () => {
+    await cmdShare('next', 'MEX', {}, {
+      cfg: cfg(),
+      t: makeT('en'),
+      adapter: windowAdapter([r32MexEcu()]),
+      now: KNOCKOUT_NOW,
+      marketProvider: undefined,
+    });
+    const data = json() as { kind: string; matches: Match[]; source: string | null };
+    expect(data.kind).toBe('next');
+    expect(data.matches[0]?.away.code).toBe('ECU');
+    // Overlay resolved the tie ⇒ attribute the provider, parity with `next`.
+    expect(data.source).toBe('espn');
+  });
+
+  it('feed outage: the pasted card never reads as "no fixture" (text)', async () => {
+    await cmdShare('next', 'MEX', {}, {
+      cfg: cfg({ json: false }),
+      t: makeT('en'),
+      adapter: windowAdapter([], { throws: true }),
+      now: KNOCKOUT_NOW,
+      marketProvider: undefined,
+    });
+    const t = text();
+    expect(t).toContain("Couldn't reach the data provider");
+    expect(t).not.toContain('Live data:'); // no attribution on degraded
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,11 +53,12 @@ export {
   getMatchById,
   getStandings,
   getBracket,
+  getNextFixtureForTeam,
   marketFixtureForTeam,
   resolveCompetition,
   liveSourceLabel,
 } from './live';
-export type { LiveResult, MatchByIdResult, StandingsResult } from './live';
+export type { LiveResult, MatchByIdResult, NextFixtureResult, StandingsResult } from './live';
 export type { BracketResult, BracketView } from './bracket/types';
 export { DEFAULT_COMPETITION, competitionBase } from './adapters/espn';
 

--- a/packages/core/src/live.ts
+++ b/packages/core/src/live.ts
@@ -251,6 +251,60 @@ export async function marketFixtureForTeam(
   return { match: next, degraded: false };
 }
 
+export interface NextFixtureResult {
+  fixture?: Match;
+  /** True when the live overlay fetch failed and only the static skeleton was used. */
+  degraded: boolean;
+  /** The provider that served the live overlay (absent when degraded). */
+  source?: string;
+}
+
+/**
+ * A team's next UPCOMING fixture, LIVE-RESOLVED across the knockout phase.
+ *
+ * The bundled schedule's knockout slots are resultless placeholders (home/away
+ * are slot refs like "Group A winner", never a nation — see
+ * {@link sanitizeBundledFixture}), so a purely static lookup goes blind the
+ * moment a team's last GROUP game passes: `next MEX` answers "no upcoming
+ * fixture" even after ESPN has confirmed Mexico's Round-of-32 tie. Overlay the
+ * live knockout window (the SAME single fetch {@link getBracket} uses) so the
+ * merged set carries the resolved nations, then pick the team's next fixture
+ * with kickoff ≥ now. (Strictly upcoming — the in-play match is `getLiveMatches`'
+ * job, preserving the pre-overlay `next` semantics.)
+ *
+ * Fails closed: on any provider error it falls back to the static result
+ * (`degraded: true`), so a feed outage degrades to "no fixture" rather than
+ * inventing one — advancement is never read from the static skeleton.
+ */
+export async function getNextFixtureForTeam(
+  adapter: ProviderAdapter,
+  code: string,
+  now: Date = new Date(),
+): Promise<NextFixtureResult> {
+  const base = allFixtures();
+  let matches = base;
+  let degraded = true;
+  let liveById: Set<string> | undefined;
+  try {
+    const live = adapter.fetchWindow
+      ? await adapter.fetchWindow(KNOCKOUT_WINDOW_START, KNOCKOUT_WINDOW_END)
+      : [];
+    matches = mergeLive(base, live);
+    degraded = false;
+    liveById = new Set(live.map((m) => m.id));
+  } catch {
+    // Static skeleton only — fail closed; never invent a knockout pairing.
+  }
+  // Strictly the next UPCOMING fixture (kickoff ≥ now), preserving the pre-overlay
+  // `next` semantics — the in-play match is `live`'s job, not `next`'s.
+  const fixture = nextFixtureForTeam(code, { from: now, fixtures: matches });
+  // Attribute the provider only when the live overlay actually served the chosen
+  // fixture — a static group game (not in the knockout-window fetch) is not
+  // "Live data: ESPN". Mirrors getMatchById's hit-based attribution.
+  const source = fixture && liveById?.has(fixture.id) ? adapter.name : undefined;
+  return { fixture, degraded, source };
+}
+
 /**
  * A single match by id, with live overlay. The provider's scoreboard buckets
  * days in its own zone (ESPN: US/Eastern), so a fixture's UTC date can differ

--- a/packages/core/test/live.test.ts
+++ b/packages/core/test/live.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { getLiveMatches, getMatchesForDate, type Match, type ProviderAdapter } from '../src/index';
+import {
+  getLiveMatches,
+  getMatchesForDate,
+  getNextFixtureForTeam,
+  type Match,
+  type ProviderAdapter,
+} from '../src/index';
 
 function fx(id: string, kickoff: string, over: Partial<Match> = {}): Match {
   return {
@@ -168,5 +174,81 @@ describe('getLiveMatches — windowed in-play detection (P1)', () => {
     const { matches, degraded } = await getLiveMatches(adapter, new Date('2026-06-17T05:00:00Z'));
     expect(degraded).toBe(true);
     expect(matches).toEqual([]);
+  });
+});
+
+describe('getNextFixtureForTeam — live-resolved across the knockout phase', () => {
+  // After the group stage the bundled knockout slots are placeholders (codes
+  // like 2A/2B, flag 🏳️), so a static lookup is blind. The live overlay carries
+  // the real pairing once ESPN assigns it.
+  const KNOCKOUT_NOW = new Date('2026-06-28T12:00:00Z'); // R32 day, group stage done
+
+  it('resolves a confirmed Round-of-32 tie from the live overlay (the bug)', async () => {
+    // Overlay the bundled R32 id 760486 (a 2A-vs-2B placeholder) with the
+    // confirmed Mexico vs Ecuador pairing ESPN has filed.
+    const r32 = fx('760486', '2026-06-30T18:00Z', {
+      stage: 'R32',
+      group: undefined,
+      home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+      away: { code: 'ECU', name: 'Ecuador', flag: '🇪🇨' },
+    });
+    const { adapter, calls } = windowAdapter([r32]);
+
+    const { fixture, degraded, source } = await getNextFixtureForTeam(adapter, 'MEX', KNOCKOUT_NOW);
+
+    expect(degraded).toBe(false);
+    expect(calls).toEqual([['20260628', '20260719']]); // the knockout window
+    expect(fixture?.id).toBe('760486');
+    expect(fixture?.away.code).toBe('ECU');
+    // Live overlay served this fixture → attribute the provider.
+    expect(source).toBe('win');
+  });
+
+  it('case-insensitive team code', async () => {
+    const r32 = fx('760486', '2026-06-30T18:00Z', {
+      stage: 'R32',
+      group: undefined,
+      home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+      away: { code: 'ECU', name: 'Ecuador', flag: '🇪🇨' },
+    });
+    const { adapter } = windowAdapter([r32]);
+    const { fixture } = await getNextFixtureForTeam(adapter, 'mex', KNOCKOUT_NOW);
+    expect(fixture?.id).toBe('760486');
+  });
+
+  it('mid-group: the next GROUP fixture still wins and is NOT attributed to the overlay', async () => {
+    // Empty knockout window; the team's next group game comes from the static
+    // bundle, so it must not carry a live-provider attribution.
+    const { adapter } = windowAdapter([]);
+    const { fixture, degraded, source } = await getNextFixtureForTeam(
+      adapter,
+      'MEX',
+      new Date('2026-06-13T12:00:00Z'),
+    );
+    expect(degraded).toBe(false);
+    expect(fixture?.stage).toBe('GROUP');
+    expect(source).toBeUndefined();
+  });
+
+  it('fails closed on a provider error: degraded, no invented knockout pairing', async () => {
+    const adapter: ProviderAdapter = {
+      name: 'boom',
+      capabilities: { push: false, latencyHintSec: 0 },
+      async fetchByDate() {
+        return [];
+      },
+      async fetchLive() {
+        return [];
+      },
+      async fetchWindow() {
+        throw new Error('down');
+      },
+    };
+    const { fixture, degraded, source } = await getNextFixtureForTeam(adapter, 'MEX', KNOCKOUT_NOW);
+    expect(degraded).toBe(true);
+    // The static skeleton has only a placeholder R32 slot for MEX, never a real
+    // pairing — so no fixture, rather than a confidently-wrong one.
+    expect(fixture).toBeUndefined();
+    expect(source).toBeUndefined();
   });
 });

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -159,10 +159,10 @@ export function buildServer(): McpServer {
     {
       title: 'Next fixture for a team',
       description:
-        "A team's next scheduled match. Use a 3-letter code, e.g. MEX, BRA, USA. Instant and offline — answered from the bundled schedule, no network.",
+        "A team's next match, live-resolved: a confirmed knockout tie (Round of 32 onward) is read from the live overlay, group fixtures from the bundled schedule. Use a 3-letter code, e.g. MEX, BRA, USA. Falls back to the bundled schedule if the provider is unreachable.",
       inputSchema: { team: teamArg.describe('3-letter team code, e.g. MEX'), ...commonArgs },
-      // Read-only and served entirely from the bundled static schedule.
-      annotations: { readOnlyHint: true, openWorldHint: false },
+      // Read-only; overlays live provider data for knockout pairings, so open-world.
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) => toContent(await toolGetNextFixture(args)),
   );

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -18,6 +18,7 @@ import {
   getMarketSignals,
   getMatchById,
   getMatchesForDate,
+  getNextFixtureForTeam,
   getStandings,
   hasSaneDistribution,
   isReliableMarketSignal,
@@ -32,7 +33,6 @@ import {
   type Match,
   type MarketProvider,
   type MarketSignal,
-  nextFixtureForTeam,
   type ProviderAdapter,
   resolveCompetition,
   resolveMarketSource,
@@ -371,25 +371,34 @@ export async function standingsResourceText(
   return withDisclaimer(text, source);
 }
 
-/** next_fixture: a team's next match (static schedule). */
+/** next_fixture: a team's next match, live-resolved across the knockout phase. */
 export async function toolGetNextFixture(
   args: { team: string } & CommonOpts,
 ): Promise<ToolResult> {
   const code = args.team.toUpperCase();
-  // Thread the caller's clock so "next fixture" is deterministic in tests and
-  // doesn't silently resolve against the real wall-clock (which goes null once a
-  // team's last *known* fixture passes — knockouts are placeholders).
-  const fixture = nextFixtureForTeam(code, { from: args.now ?? new Date() });
+  // Overlay the live knockout window so a confirmed R32+ tie resolves: the
+  // bundled knockout slots are placeholders, so a static lookup goes blind once
+  // a team's group games pass (it would answer "no upcoming fixture" even after
+  // ESPN confirmed the tie). Fails closed to the static result on a feed outage.
+  // The caller's clock is still threaded for deterministic tests.
+  const { fixture, degraded, source } = await getNextFixtureForTeam(
+    resolveAdapter(args),
+    code,
+    args.now ?? new Date(),
+  );
   if (!fixture) {
+    const msg = degraded
+      ? `Couldn't reach the data provider — no upcoming fixture confirmed for ${code}.`
+      : `No upcoming fixture found for ${code}.`;
     return {
-      text: withDisclaimer(`No upcoming fixture found for ${code}.`),
-      data: { team: code, fixture: null },
+      text: withDisclaimer(msg, undefined, args.lang),
+      data: { team: code, fixture: null, degraded },
     };
   }
   const opts = fmtOpts(args);
   return {
-    text: withDisclaimer(`Next up for ${code}:\n${matchLine(fixture, opts)}`),
-    data: { team: code, fixture },
+    text: withDisclaimer(`Next up for ${code}:\n${matchLine(fixture, opts)}`, source, args.lang),
+    data: { team: code, fixture, degraded },
   };
 }
 
@@ -692,10 +701,16 @@ export async function toolGetShareSnippet(args: ShareArgs): Promise<ToolResult> 
     );
   }
 
-  // a team's next fixture (static schedule + reliable market read).
+  // a team's next fixture, live-resolved across the knockout phase (+ market read).
   if (args.team) {
     const code = args.team.toUpperCase();
-    const fixture = nextFixtureForTeam(code, { from: args.now ?? new Date() });
+    // Overlay the live knockout window so a confirmed R32+ tie pastes too (see
+    // getNextFixtureForTeam / toolGetNextFixture); fail closed on an outage.
+    const { fixture, degraded, source } = await getNextFixtureForTeam(
+      resolveAdapter(args),
+      code,
+      args.now ?? new Date(),
+    );
     const matches = fixture ? [fixture] : [];
     const teamName = fixture
       ? fixture.home.code === code
@@ -710,7 +725,13 @@ export async function toolGetShareSnippet(args: ShareArgs): Promise<ToolResult> 
         title: `Next up for ${teamName}`,
         matches,
         marketSignals: await signalsFor(matches),
-        emptyNote: `No upcoming fixture found for ${code}.`,
+        // Attribute the provider only when the overlay resolved the tie; parity
+        // with get_next_fixture (a static group fixture carries no source).
+        source,
+        degraded,
+        emptyNote: degraded
+          ? `Couldn't reach the data provider — no upcoming fixture confirmed for ${code}.`
+          : `No upcoming fixture found for ${code}.`,
         installLine: `npx @claudinho/cli next ${code}`,
         tz: args.tz,
         locale: args.lang,

--- a/packages/mcp/test/share.test.ts
+++ b/packages/mcp/test/share.test.ts
@@ -110,15 +110,64 @@ describe('toolGetShareSnippet', () => {
 
   it("resolves a team's next fixture", async () => {
     const team = allFixtures()[0]!.home.code;
-    const r = await toolGetShareSnippet({ team, marketProvider: synth(), adapter: fakeAdapter });
+    // Pin a group-stage clock so the static path deterministically finds a real
+    // fixture (the title is always "Next up for …", so a real now could rot into
+    // exercising the empty path while still passing — see rule 6 / rule 1).
+    const r = await toolGetShareSnippet({
+      team,
+      now: TEST_NOW,
+      marketProvider: synth(),
+      adapter: fakeAdapter,
+    });
     const data = r.data as ShareData;
     expect(data.kind).toBe('next');
     expect(data.team).toBe(team);
+    expect(data.matches.length).toBe(1); // a real fixture, not the empty card
     expect(data.informationalOnly).toBe(true);
     expect(r.text).toContain(`Next up for`);
     expect(r.text).toContain(HASHTAG);
     expect(r.text).toContain(DISCLAIMER);
     expect(r.text).toContain(`Try it: npx @claudinho/cli next ${team}`);
+  });
+
+  it("resolves a team's confirmed knockout tie from the live overlay", async () => {
+    // Overlay the bundled R32 placeholder (id 760486) with Mexico vs Ecuador.
+    const r32: Match = {
+      id: '760486',
+      stage: 'R32',
+      kickoff: '2026-06-30T18:00Z',
+      venue: 'SoFi Stadium',
+      home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+      away: { code: 'ECU', name: 'Ecuador', flag: '🇪🇨' },
+      status: 'SCHEDULED',
+      updatedAt: '2026-06-28T00:00Z',
+    };
+    const koAdapter: ProviderAdapter = {
+      name: 'espn',
+      capabilities: { push: false, latencyHintSec: 0 },
+      async fetchByDate() {
+        return [];
+      },
+      async fetchLive() {
+        return [];
+      },
+      async fetchWindow() {
+        return [r32];
+      },
+    };
+    const r = await toolGetShareSnippet({
+      team: 'MEX',
+      now: new Date('2026-06-28T12:00:00Z'), // group stage done
+      marketProvider: synth(),
+      adapter: koAdapter,
+    });
+    const data = r.data as ShareData & { source: string | null };
+    expect(data.kind).toBe('next');
+    expect(data.matches[0]?.away.code).toBe('ECU');
+    expect(r.text).toContain('Ecuador');
+    // Overlay resolved the tie ⇒ attribute the provider (parity with get_next_fixture).
+    expect(data.source).toBe('espn');
+    expect(r.text).toContain('Live data: ESPN');
   });
 
   it('renders a clear empty state for an unknown team (not a void card)', async () => {
@@ -307,6 +356,36 @@ describe('toolGetShareSnippet — degraded honesty (feed down)', () => {
     expect(data.degraded).toBe(true);
     expect(data.source).toBeNull();
     expect(r.text).toContain('Live data unavailable — showing the bundled schedule, not live scores.');
+    expect(r.text).not.toContain('Live data:');
+    expect(r.text).toContain(DISCLAIMER);
+  });
+
+  it('next: says the provider is unreachable — never pastes as "no fixture" (eliminated)', async () => {
+    // Knockout-window fetch throws ⇒ a post-group-stage team has only a static
+    // placeholder slot, so the card must read "couldn't reach the provider", not
+    // a flat "no upcoming fixture" (which scans as the team being out).
+    const windowDown: ProviderAdapter = {
+      name: 'espn',
+      capabilities: { push: false, latencyHintSec: 0 },
+      async fetchByDate() {
+        throw new Error('ESPN 403');
+      },
+      async fetchLive() {
+        throw new Error('ESPN 403');
+      },
+      async fetchWindow() {
+        throw new Error('ESPN 403');
+      },
+    };
+    const r = await toolGetShareSnippet({
+      team: 'MEX',
+      now: new Date('2026-06-28T12:00:00Z'),
+      adapter: windowDown,
+      marketProvider: synth(),
+    });
+    const data = r.data as { degraded: boolean };
+    expect(data.degraded).toBe(true);
+    expect(r.text).toContain("Couldn't reach the data provider");
     expect(r.text).not.toContain('Live data:');
     expect(r.text).toContain(DISCLAIMER);
   });

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -151,17 +151,64 @@ describe('toolGetToday', () => {
   });
 });
 
-describe('toolGetNextFixture (pure static)', () => {
-  it('returns the next fixture for a team code', async () => {
-    const r = await toolGetNextFixture({ team: 'bra', now: TEST_NOW });
+describe('toolGetNextFixture (live-resolved knockout)', () => {
+  // A confirmed R32 tie ESPN has filed over the bundled placeholder slot.
+  function r32MexEcu(): Match {
+    return {
+      id: '760486',
+      stage: 'R32',
+      kickoff: '2026-06-30T18:00Z',
+      venue: 'SoFi Stadium',
+      home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+      away: { code: 'ECU', name: 'Ecuador', flag: '🇪🇨' },
+      status: 'SCHEDULED',
+      updatedAt: '2026-06-28T00:00Z',
+    };
+  }
+
+  it('returns the next group fixture mid-group (from the static bundle)', async () => {
+    const r = await toolGetNextFixture({
+      team: 'bra',
+      now: TEST_NOW, // 2026-06-13 — group stage
+      adapter: fakeAdapter({ window: [] }),
+    });
     const data = r.data as { team: string; fixture: Match | null };
     expect(data.team).toBe('BRA');
     expect(data.fixture).toBeTruthy();
     expect(r.text).toContain('Next up for BRA');
   });
 
+  it('resolves a confirmed knockout tie from the live overlay (the bug)', async () => {
+    const r = await toolGetNextFixture({
+      team: 'MEX',
+      now: new Date('2026-06-28T12:00:00Z'), // group stage done; R32 day
+      adapter: fakeAdapter({ window: [r32MexEcu()] }),
+    });
+    const data = r.data as { fixture: Match | null; degraded: boolean };
+    expect(data.fixture?.away.code).toBe('ECU');
+    expect(data.degraded).toBe(false);
+    expect(r.text).toContain('Next up for MEX');
+    expect(r.text).toContain('Ecuador');
+  });
+
+  it('fails closed on a feed outage (degraded note, no invented pairing)', async () => {
+    const r = await toolGetNextFixture({
+      team: 'MEX',
+      now: new Date('2026-06-28T12:00:00Z'),
+      adapter: fakeAdapter({ throws: true }),
+    });
+    const data = r.data as { fixture: Match | null; degraded: boolean };
+    expect(data.degraded).toBe(true);
+    expect(data.fixture).toBeNull(); // only a placeholder slot statically → null
+    expect(r.text).toContain("Couldn't reach the data provider");
+  });
+
   it('handles an unknown team gracefully', async () => {
-    const r = await toolGetNextFixture({ team: 'ZZZ' });
+    const r = await toolGetNextFixture({
+      team: 'ZZZ',
+      now: TEST_NOW,
+      adapter: fakeAdapter({ window: [] }),
+    });
     expect((r.data as { fixture: null }).fixture).toBeNull();
   });
 });


### PR DESCRIPTION
## The bug

`claudinho next MEX` returned **"No upcoming fixture found for MEX"** even though Mexico had a confirmed Round-of-32 tie vs Ecuador — while the bracket already showed it. `next`, `share next`, MCP `get_next_fixture`, and MCP `get_share_snippet { next }` all resolved a team's next match from the **static bundle only**, whose knockout slots are resultless placeholders (codes like `2A`/`2B`, flag 🏳️). So once a team's group games passed, its knockout fixture was invisible.

Same root-cause family as the 0.8.6 third-place bug: a surface not reading the live overlay.

## The fix

New core `getNextFixtureForTeam(adapter, code, now)` overlays the **live knockout window** (the same single fetch `getBracket` uses) over the bundle and returns the team's next **upcoming** fixture (kickoff ≥ now).

- **Fails closed:** a provider error degrades to the static result, never an invented pairing (advancement only from the live overlay).
- **Attribution precision:** `source` is set only when the overlay actually served the chosen fixture — a static group game carries no `Live data: ESPN` (mirrors `getMatchById`).
- **Every surface:** wired into all four interactive surfaces (CLI text + `--json`, MCP `data` + text, both share twins), each threading tz/lang and a fail-closed "couldn't reach the provider" note so an outage never reads as "no fixture" (eliminated).
- **Hot path untouched:** the statusline/hook still resolve next-fixture purely from the static cache (no network).

## MCP-affecting

`get_next_fixture` flips offline→network, so its description and `openWorldHint` are updated → **MCP Registry republish required** on release. README FAQ offline claim corrected.

## Known gap (separate, batchable)

The **statusline** next-fixture countdown is hot-path (live-only cache), so for a team between its group finish and its knockout game it shows `⚽ —` rather than the knockout countdown — fail-closed (absent, not wrong). Fixing it needs a cold-path/refresher change to cache resolved knockout fixtures.

## Verification

Verified end-to-end against the **real ESPN feed**: `next MEX` → 🇲🇽 Mexico vs Ecuador 🇪🇨 (R32), `next GER` → vs Paraguay; group teams resolve statically with no false attribution; in-play/eliminated/unknown teams fail closed honestly; `es`+tz threading intact. An independent adversarial review pass found one P2 (share-next attribution parity) + one P3 (docstring), both fixed.

Tests: core 195 / cli 186 / mcp 65, lint + `release:qa` (4/4 tripwires) green.

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>