### PR TITLE
fix(statusline): address #48 review (empty-fetch TTL, syncing 🏳️ leak, hook parity)

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -518,7 +518,11 @@ export function cmdHook({ cfg }: Ctx): void {
     const state = readCurrentState(cfg.source, resolveCompetition());
     const ctx = renderHook(state, { team, flags: flagsEnabled() });
     if (ctx) out(ctx);
-    if (!state || shouldRefresh()) spawnRefresh(cfg.source);
+    // Warm the same cache the statusline reads, for parity (the hook itself shows
+    // only live scores). Spawn for live OR stale knockout fixtures.
+    if (!state || shouldRefresh() || shouldRefreshFixtures(Date.now(), state)) {
+      spawnRefresh(cfg.source);
+    }
   } catch {
     // Never block the prompt — emit nothing on any error.
   }

--- a/packages/cli/src/refresh.ts
+++ b/packages/cli/src/refresh.ts
@@ -40,6 +40,26 @@ const MIN_REFRESH_MS = 12_000;
  */
 const FIXTURES_TTL_MS = 15 * 60_000;
 
+/**
+ * BUT a successful fetch that returns ZERO resolved fixtures (ESPN hasn't filed
+ * the pairings yet — the phase boundary, or the first poll as knockouts lock in)
+ * must NOT suppress re-polling for the full 15min, or the statusline sits on
+ * "⚽ —" long after the pairings appear. So an empty result is trusted only
+ * briefly. (A provider ERROR is different — handled fail-closed by keeping the
+ * prior cache; this is about a real-but-empty success.)
+ */
+const FIXTURES_EMPTY_TTL_MS = 60_000;
+
+/**
+ * Whether the cached knockout `fixtures` are stale enough to refetch. Uses the
+ * short empty-TTL when the cache holds no resolved fixtures (re-poll soon at the
+ * boundary), the long TTL once it holds some (pairings are stable).
+ */
+function fixturesStale(state: CacheState | undefined, now: number): boolean {
+  const ttl = (state?.fixtures?.length ?? 0) > 0 ? FIXTURES_TTL_MS : FIXTURES_EMPTY_TTL_MS;
+  return fixturesAgeMs(state, now) >= ttl;
+}
+
 /** The soonest upcoming static fixture (cheap; bundle is in memory). */
 function nextStaticUpcoming(nowMs: number): Match | undefined {
   return [...allFixtures()].sort(byKickoff).find((m) => Date.parse(m.kickoff) >= nowMs);
@@ -105,8 +125,7 @@ export async function runRefresh(opts: RefreshOpts = {}): Promise<void> {
   // fixtures fetch, or vice-versa.
   const needLive =
     liveWindowActive(nowMs) && (!base || ageMs(base, nowMs) >= MIN_REFRESH_MS);
-  const needFixtures =
-    inKnockoutPhase(nowMs) && (!base || fixturesAgeMs(base, nowMs) >= FIXTURES_TTL_MS);
+  const needFixtures = inKnockoutPhase(nowMs) && fixturesStale(base, nowMs);
   if (!needLive && !needFixtures) return;
 
   if (!acquireLock()) return;
@@ -189,7 +208,7 @@ export function shouldRefreshFixtures(
 ): boolean {
   if (!inKnockoutPhase(now)) return false;
   if (isLockFresh(now)) return false;
-  return fixturesAgeMs(state, now) > FIXTURES_TTL_MS;
+  return fixturesStale(state, now);
 }
 
 /**

--- a/packages/cli/src/refresh.ts
+++ b/packages/cli/src/refresh.ts
@@ -57,7 +57,7 @@ const FIXTURES_EMPTY_TTL_MS = 60_000;
  */
 function fixturesStale(state: CacheState | undefined, now: number): boolean {
   const ttl = (state?.fixtures?.length ?? 0) > 0 ? FIXTURES_TTL_MS : FIXTURES_EMPTY_TTL_MS;
-  return fixturesAgeMs(state, now) >= ttl;
+  return fixturesAgeMs(state, now) > ttl; // `>` to match shouldRefresh's LIVE_TTL boundary
 }
 
 /** The soonest upcoming static fixture (cheap; bundle is in memory). */

--- a/packages/cli/src/statusline.ts
+++ b/packages/cli/src/statusline.ts
@@ -134,6 +134,14 @@ export function renderPrompt(state: CacheState | undefined, opts: PromptOpts = {
 
   const live = liveMatchesFromCache(state, nowMs);
 
+  // The static bundle MERGED with the refresher's cached resolved knockout
+  // fixtures — the bundle's KO slots are 🏳️ placeholders the hot path can't
+  // resolve itself, so this overlay is how the statusline shows real pairings
+  // (still NETWORK-FREE: reads only the cache). Used by both the syncing and
+  // next-fixture branches below.
+  const cachedFixtures = Array.isArray(state?.fixtures) ? (state!.fixtures as Match[]) : [];
+  const schedule = cachedFixtures.length ? mergeLive(allFixtures(), cachedFixtures) : undefined;
+
   // With a team filter, show only that team's live match.
   if (team) {
     const mine = live.find((m) => m.home?.code === team || m.away?.code === team);
@@ -159,27 +167,25 @@ export function renderPrompt(state: CacheState | undefined, opts: PromptOpts = {
   const cacheFresh =
     !!state && state.degraded !== true && ageMs(state, nowMs) < DISPLAY_STALE_MS;
   if (!cacheFresh) {
-    const win = fixturesInLiveWindow(nowMs).filter(
+    const win = fixturesInLiveWindow(nowMs, schedule).filter(
       (m) => !team || m.home.code === team || m.away.code === team,
     );
     const first = win[0];
     if (first) {
       const more = win.length - 1;
-      return (
-        `⚽ ${teamTok(first.home, flags)} vs ${teamTok(first.away, flags)} live · syncing…` +
-        (more > 0 ? ` +${more}` : '')
-      );
+      // Drop the matchup when the in-window fixture is still a 🏳️ placeholder
+      // (a knockout the overlay hasn't resolved) — never paste "🏳️ vs 🏳️"; just
+      // say a match is on and we're syncing.
+      const matchup = isResolvedFixture(first)
+        ? `${teamTok(first.home, flags)} vs ${teamTok(first.away, flags)} `
+        : '';
+      return `⚽ ${matchup}live · syncing…` + (more > 0 ? ` +${more}` : '');
     }
   }
 
-  // Nothing (relevant) live → next-fixture countdown. Resolve over the static
-  // bundle MERGED with the refresher's cached resolved knockout fixtures, so a
-  // confirmed pairing (e.g. 🇲🇽 vs 🇪🇨) shows here too — the bundle's KO slots are
-  // 🏳️ placeholders the hot path can't resolve itself. Still NETWORK-FREE: reads
-  // only the cache. Unresolved slots stay placeholders and are skipped, so this
-  // fails closed to "⚽ —", never "🏳️ vs 🏳️".
-  const cachedFixtures = Array.isArray(state?.fixtures) ? (state!.fixtures as Match[]) : [];
-  const schedule = cachedFixtures.length ? mergeLive(allFixtures(), cachedFixtures) : undefined;
+  // Nothing (relevant) live → next-fixture countdown over the merged schedule
+  // (resolved knockout pairings show; unresolved 🏳️ slots are skipped, so this
+  // fails closed to "⚽ —", never "🏳️ vs 🏳️").
   const next = team
     ? nextFixtureForTeam(team, { from: now, fixtures: schedule })
     : nextOverall(nowMs, schedule);

--- a/packages/cli/test/knockout-surface-coverage.test.ts
+++ b/packages/cli/test/knockout-surface-coverage.test.ts
@@ -14,10 +14,10 @@
  * stops live-resolving, this fails. See `.cursor/rules/surface-parity.mdc` and
  * AGENTS.md "Knockout surfaces live-resolve".
  *
- * The statusline is the one surface that CANNOT live-fetch (hot path, <150ms,
- * cache-only) — its contract is the opposite: it must FAIL CLOSED (never leak a
- * placeholder/wrong team) until the refresher caches resolved knockout fixtures
- * (tracked follow-up). That contract is asserted at the bottom.
+ * The statusline can't live-fetch (hot path, <150ms, cache-only), so it
+ * live-resolves INDIRECTLY: the refresher caches resolved knockout fixtures and
+ * the statusline reads them, failing closed to "⚽ —" (never a placeholder leak)
+ * when the cache lacks the pairing. Both contracts are asserted at the bottom.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Match, ProviderAdapter } from '@claudinho/core';

--- a/packages/cli/test/refresh.test.ts
+++ b/packages/cli/test/refresh.test.ts
@@ -177,6 +177,40 @@ describe('knockout fixtures cadence (statusline countdown across the knockouts)'
     expect(shouldRefreshFixtures(KO_NOW)).toBe(false);
   });
 
+  it('re-polls an EMPTY successful fetch on a SHORT TTL (boundary), long TTL once filled', () => {
+    const base = {
+      updatedAt: '2026-06-28T11:00:00Z',
+      live: [],
+      degraded: false,
+      source: 'espn',
+      competition: 'fifa.world',
+    };
+    const resolved: Match = {
+      id: '760491',
+      stage: 'R32',
+      kickoff: '2026-06-30T18:00Z',
+      venue: 'X',
+      home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+      away: { code: 'ECU', name: 'Ecuador', flag: '🇪🇨' },
+      status: 'SCHEDULED',
+      updatedAt: '2026-06-28T00:00Z',
+    };
+    const stamp = (ms: number) => new Date(KO_NOW - ms).toISOString();
+    // Empty fixtures (ESPN hasn't filed pairings) stamped 90s ago → short
+    // (60s) TTL exceeded → re-poll, so the statusline can't sit on "⚽ —".
+    expect(
+      shouldRefreshFixtures(KO_NOW, { ...base, fixtures: [], fixturesUpdatedAt: stamp(90_000) }),
+    ).toBe(true);
+    // Empty, but only 30s ago → within the short TTL → don't stampede.
+    expect(
+      shouldRefreshFixtures(KO_NOW, { ...base, fixtures: [], fixturesUpdatedAt: stamp(30_000) }),
+    ).toBe(false);
+    // Once filled, the same 90s age is well within the long (15min) TTL.
+    expect(
+      shouldRefreshFixtures(KO_NOW, { ...base, fixtures: [resolved], fixturesUpdatedAt: stamp(90_000) }),
+    ).toBe(false);
+  });
+
   it('runRefresh caches the resolved knockout fixtures (no live match on now)', async () => {
     vi.stubGlobal(
       'fetch',

--- a/packages/cli/test/refresh.test.ts
+++ b/packages/cli/test/refresh.test.ts
@@ -226,4 +226,24 @@ describe('knockout fixtures cadence (statusline countdown across the knockouts)'
       vi.unstubAllGlobals();
     }
   });
+
+  it('runRefresh re-polls an EMPTY fixtures cache only after the short TTL', async () => {
+    // ESPN hasn't filed pairings yet → empty success. No live match at 12:00, so
+    // every fetch here is a fixtures fetch — count them across three cycles.
+    const fetchSpy = vi.fn(async () => ({ ok: true, json: async () => ({ day: {}, events: [] }) }));
+    vi.stubGlobal('fetch', fetchSpy);
+    try {
+      await runRefresh({ now: new Date(KO_NOW), source: 'espn' }); // fetch #1 → empty
+      expect(readState()?.fixtures).toEqual([]);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      await runRefresh({ now: new Date(KO_NOW + 30_000), source: 'espn' }); // within 60s → no fetch
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      await runRefresh({ now: new Date(KO_NOW + 90_000), source: 'espn' }); // past 60s → refetch
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });

--- a/packages/cli/test/statusline.test.ts
+++ b/packages/cli/test/statusline.test.ts
@@ -172,6 +172,46 @@ describe('renderPrompt — knockout next fixture from cached resolved fixtures',
   });
 });
 
+describe('renderPrompt — stale cache during a knockout match (live · syncing)', () => {
+  // The bundled R32 760486 kicks off 19:00Z as a 🏳️ placeholder. With a STALE
+  // cache (>5min) it hits the "live · syncing" branch from the static skeleton.
+  const DURING_KO = new Date('2026-06-28T19:30:00Z'); // inside 760486's live window
+  const staleBase = (over: Partial<CacheState> = {}): CacheState => ({
+    updatedAt: '2026-06-28T19:20:00Z', // 10min stale → cacheFresh false
+    live: [],
+    degraded: false,
+    source: 'espn',
+    competition: 'fifa.world',
+    ...over,
+  });
+
+  it('does NOT leak "🏳️ vs 🏳️" — drops the matchup when unresolved', () => {
+    const line = renderPrompt(staleBase(), { now: DURING_KO });
+    expect(line).toContain('live · syncing');
+    expect(line).not.toContain('🏳️');
+  });
+
+  it('shows the real teams when the cache carries the resolved pairing', () => {
+    const resolved: Match = {
+      id: '760486',
+      stage: 'R32',
+      kickoff: '2026-06-28T19:00Z',
+      venue: 'X',
+      home: { code: 'RSA', name: 'RSA', flag: '🇿🇦' },
+      away: { code: 'CAN', name: 'CAN', flag: '🇨🇦' },
+      status: 'SCHEDULED',
+      updatedAt: '2026-06-28T19:00Z',
+    };
+    const line = renderPrompt(
+      staleBase({ fixtures: [resolved], fixturesUpdatedAt: '2026-06-28T19:00:00Z' }),
+      { now: DURING_KO },
+    );
+    expect(line).toContain('🇿🇦');
+    expect(line).toContain('live · syncing');
+    expect(line).not.toContain('🏳️');
+  });
+});
+
 describe('flagsEnabled', () => {
   it('honors an explicit off/on (any common spelling)', () => {
     for (const v of ['off', '0', 'no', 'false', 'OFF']) {


### PR DESCRIPTION
Follow-up to #48 addressing your review. **Holding this open for your review — not auto-merging.**

## P2 — empty successful fetch suppressed re-poll for 15 min
A non-degraded `getKnockoutFixtures` returning `[]` (ESPN hasn't filed pairings yet — the phase boundary) stamped `fixturesUpdatedAt` on the full 15 min TTL, so the statusline could sit on `⚽ —` for up to 15 min after pairings appear.

Fix: an **empty** result is trusted only briefly — `FIXTURES_EMPTY_TTL_MS = 60s` — via a `fixturesStale(state, now)` helper used by both `runRefresh` and `shouldRefreshFixtures`. A **populated** cache keeps the 15 min TTL; a provider **error** stays fail-closed (prior cache kept). Re-poll stays bounded by the lock (~1/min at the boundary).

## P2 — `live · syncing…` could still leak `🏳️ vs 🏳️`
The stale-cache syncing branch read the static skeleton. It now resolves over the merged schedule and **drops the matchup** when the in-window fixture is an unresolved placeholder → `⚽ live · syncing…`, never `🏳️`. (Zero `🏳️` anywhere on the statusline now.)

## P3 — `cmdHook` parity + stale comment
`cmdHook` now also triggers a fixtures refresh (parity with `cmdPrompt`). Coverage-test header comment updated (positive case is implemented; no longer a "tracked follow-up").

## P3 — dual ESPN fetch (accepted, no change)
During a knockout live window with stale fixtures, `runRefresh` may issue both the live (±1d) and knockout-window fetches. Cold path, ~1 extra fetch per 15 min; deduping means refactoring `getLiveMatches`' window — not worth the risk.

## Tests
Empty-vs-filled fixtures TTL (`shouldRefreshFixtures`); syncing branch no-`🏳️` + resolved-overlay. `core 199 / cli 202 / mcp 69`, lint + `release:qa` green. Not MCP-affecting.

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>