### PR TITLE
fix(core): show penalty shootout tallies in scorelines

### DIFF
--- a/packages/core/src/adapters/espn.ts
+++ b/packages/core/src/adapters/espn.ts
@@ -50,6 +50,8 @@ interface EspnTeam {
 interface EspnCompetitor {
   homeAway?: 'home' | 'away';
   score?: string;
+  /** Penalty-shootout goals when ESPN status is STATUS_FINAL_PEN. */
+  shootoutScore?: number;
   winner?: boolean;
   team?: EspnTeam;
 }
@@ -169,6 +171,14 @@ export function mapEspnEvent(ev: EspnEvent, ctx: MapContext = {}): Match {
   const hs = toInt(homeC?.score);
   const as = toInt(awayC?.score);
   const hasScore = status !== 'SCHEDULED' && hs !== undefined && as !== undefined;
+  const homePens =
+    typeof homeC?.shootoutScore === 'number' ? homeC.shootoutScore : undefined;
+  const awayPens =
+    typeof awayC?.shootoutScore === 'number' ? awayC.shootoutScore : undefined;
+  const pens =
+    homePens !== undefined && awayPens !== undefined
+      ? { home: homePens, away: awayPens }
+      : undefined;
 
   let winnerCode: string | undefined;
   if (isFinished(status)) {
@@ -186,7 +196,7 @@ export function mapEspnEvent(ev: EspnEvent, ctx: MapContext = {}): Match {
     country: comp?.venue?.address?.country || undefined,
     home,
     away,
-    score: hasScore ? { home: hs, away: as } : undefined,
+    score: hasScore ? { home: hs, away: as, ...(pens ? { pens } : {}) } : undefined,
     minute: parseMinute(ev.status ?? comp?.status),
     status,
     winnerCode,

--- a/packages/core/src/normalize.ts
+++ b/packages/core/src/normalize.ts
@@ -17,10 +17,12 @@ export function isFinished(status: Status): boolean {
   return status === 'FT';
 }
 
-/** Compact scoreline string, e.g. "1–0" (en dash) or "vs" when unscored. */
+/** Compact scoreline string, e.g. "1–0" or "1(3)–1(4)" after penalties; "vs" when unscored. */
 export function scoreline(match: Match): string {
   if (!match.score) return 'vs';
-  return `${match.score.home}–${match.score.away}`;
+  const { home, away, pens } = match.score;
+  if (pens) return `${home}(${pens.home})–${away}(${pens.away})`;
+  return `${home}–${away}`;
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -56,8 +56,12 @@ export interface Match {
   country?: string;
   home: Team;
   away: Team;
-  /** Present once the match is no longer purely SCHEDULED. */
-  score?: { home: number; away: number };
+  /**
+   * Present once the match is no longer purely SCHEDULED.
+   * `home`/`away` are regulation (+ extra time) goals; `pens` holds the
+   * shootout tally when the provider supplies it.
+   */
+  score?: { home: number; away: number; pens?: { home: number; away: number } };
   /** Live match minute when in progress. */
   minute?: number;
   status: Status;

--- a/packages/core/test/espn.test.ts
+++ b/packages/core/test/espn.test.ts
@@ -113,7 +113,7 @@ describe('mapEspnEvent', () => {
     expect(m.group).toBe('E');
   });
 
-  it('maps winnerCode from ESPN competitor.winner (e.g. penalties)', () => {
+  it('maps winnerCode from ESPN competitor.winner when pens are absent', () => {
     const pens = {
       ...finished,
       competitions: [
@@ -129,6 +129,36 @@ describe('mapEspnEvent', () => {
     const m = mapEspnEvent(pens as never, { groupByTeam: GROUP_MAP });
     expect(m.score).toEqual({ home: 1, away: 1 });
     expect(m.winnerCode).toBe('NED');
+  });
+
+  it('maps winnerCode and shootout scores from ESPN (penalties)', () => {
+    const pens = {
+      ...finished,
+      status: { type: { name: 'STATUS_FINAL_PEN', state: 'post', completed: true } },
+      competitions: [
+        {
+          ...finished.competitions[0],
+          competitors: [
+            {
+              homeAway: 'home',
+              score: '1',
+              shootoutScore: 3,
+              team: { abbreviation: 'GER', displayName: 'Germany' },
+            },
+            {
+              homeAway: 'away',
+              score: '1',
+              shootoutScore: 4,
+              winner: true,
+              team: { abbreviation: 'PAR', displayName: 'Paraguay' },
+            },
+          ],
+        },
+      ],
+    };
+    const m = mapEspnEvent(pens as never);
+    expect(m.score).toEqual({ home: 1, away: 1, pens: { home: 3, away: 4 } });
+    expect(m.winnerCode).toBe('PAR');
   });
 
   it('maps a knockout fixture from the slug, with no group letter', () => {

--- a/packages/core/test/normalize.test.ts
+++ b/packages/core/test/normalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { matchLocation, stageLabel, type Match } from '../src/index';
+import { matchLocation, scoreline, stageLabel, type Match } from '../src/index';
 
 function match(over: Partial<Match> = {}): Match {
   return {
@@ -34,6 +34,27 @@ describe('matchLocation', () => {
     expect(matchLocation(match({ city: 'Toronto', country: undefined }))).toBe(
       'Estadio Banorte, Toronto',
     );
+  });
+});
+
+describe('scoreline', () => {
+  it('returns vs when there is no score', () => {
+    expect(scoreline(match())).toBe('vs');
+  });
+
+  it('formats a regular-time score', () => {
+    expect(scoreline(match({ score: { home: 2, away: 1 }, status: 'FT' }))).toBe('2–1');
+  });
+
+  it('appends penalty tallies in parentheses after a shootout', () => {
+    expect(
+      scoreline(
+        match({
+          status: 'FT',
+          score: { home: 1, away: 1, pens: { home: 3, away: 4 } },
+        }),
+      ),
+    ).toBe('1(3)–1(4)');
   });
 });
 


### PR DESCRIPTION
## Summary
- Map ESPN `competitor.shootoutScore` into `Match.score.pens` when a knockout tie finishes on penalties (`STATUS_FINAL_PEN`).
- Format scorelines as `1(3)–1(4)` (regulation goals + shootout tally in parentheses) via the shared `scoreline()` helper.
- All surfaces pick this up automatically: `today`, `live`, `match`, statusline, share, MCP, and bracket.

## Live verification
Before:
```
🇩🇪 Germany           1–1  Paraguay 🇵🇾   FT   it's all over!
```

After:
```
🇩🇪 Germany           1(3)–1(4)  Paraguay 🇵🇾   FT   it's all over!
🇳🇱 Netherlands       1(2)–1(3)  Morocco 🇲🇦   FT   the final whistle blows!
```

## Test plan
- [x] `pnpm -r test` (475 tests pass)
- [x] `claudinho today 2026-06-29` shows pen tallies for Germany–Paraguay and Netherlands–Morocco
- [ ] MCP `get_today` / `get_match` show the same scoreline after release


Made with [Cursor](https://cursor.com)