### PR TITLE
feat(core): show penalty-shootout scores in the scoreline (1(3)–1(4))

### DIFF
--- a/packages/cli/test/format.test.ts
+++ b/packages/cli/test/format.test.ts
@@ -52,6 +52,16 @@ describe('matchLine — flavor wiring', () => {
     expect(line).toContain('South Africa');
     expect(line).not.toMatch(/\uD83C[\uDDE6-\uDDFF]/);
   });
+
+  it('renders the penalty shootout score in the line (surface inherits scoreline)', () => {
+    const pens = liveMatch({
+      status: 'FT',
+      minute: undefined,
+      score: { home: 1, away: 1 },
+      shootout: { home: 3, away: 4 },
+    });
+    expect(matchLine(pens, cfg(), makeT('en'), painterFor(cfg()))).toContain('1(3)–1(4)');
+  });
 });
 
 describe('dataSource — localized live-data attribution', () => {

--- a/packages/core/src/adapters/espn.ts
+++ b/packages/core/src/adapters/espn.ts
@@ -179,11 +179,14 @@ export function mapEspnEvent(ev: EspnEvent, ctx: MapContext = {}): Match {
   }
 
   // Penalty shootout: ESPN carries `shootoutScore` on BOTH competitors only for
-  // matches decided on penalties (absent otherwise). Keep it strictly when both
-  // are present so a regular result never grows phantom parens.
+  // matches decided on penalties (absent otherwise). Gate on `hasScore` too, so a
+  // shootout never rides without the regulation `score` it parenthesizes — the
+  // structured payload can't surface an impossible { score: undefined, shootout }
+  // (the scoreline already hides that, but `--json`/MCP `data` would expose it).
+  // `hasScore` (not `isFinished`) so a live in-progress shootout still shows.
   const hShoot = toInt(homeC?.shootoutScore);
   const aShoot = toInt(awayC?.shootoutScore);
-  const shootout = hShoot !== undefined && aShoot !== undefined
+  const shootout = hasScore && hShoot !== undefined && aShoot !== undefined
     ? { home: hShoot, away: aShoot }
     : undefined;
 

--- a/packages/core/src/adapters/espn.ts
+++ b/packages/core/src/adapters/espn.ts
@@ -50,6 +50,8 @@ interface EspnTeam {
 interface EspnCompetitor {
   homeAway?: 'home' | 'away';
   score?: string;
+  /** Penalty-shootout tally, present only on shootout matches (ESPN sends a number). */
+  shootoutScore?: number | string;
   winner?: boolean;
   team?: EspnTeam;
 }
@@ -125,9 +127,9 @@ function stageFromSlug(slug?: string): Stage {
   return 'FRIENDLY';
 }
 
-function toInt(s?: string): number | undefined {
+function toInt(s?: string | number): number | undefined {
   if (s == null || s === '') return undefined;
-  const n = parseInt(s, 10);
+  const n = parseInt(String(s), 10);
   return Number.isFinite(n) ? n : undefined;
 }
 
@@ -176,6 +178,15 @@ export function mapEspnEvent(ev: EspnEvent, ctx: MapContext = {}): Match {
     else if (awayC?.winner) winnerCode = away.code;
   }
 
+  // Penalty shootout: ESPN carries `shootoutScore` on BOTH competitors only for
+  // matches decided on penalties (absent otherwise). Keep it strictly when both
+  // are present so a regular result never grows phantom parens.
+  const hShoot = toInt(homeC?.shootoutScore);
+  const aShoot = toInt(awayC?.shootoutScore);
+  const shootout = hShoot !== undefined && aShoot !== undefined
+    ? { home: hShoot, away: aShoot }
+    : undefined;
+
   return {
     id: ev.id,
     stage,
@@ -187,6 +198,7 @@ export function mapEspnEvent(ev: EspnEvent, ctx: MapContext = {}): Match {
     home,
     away,
     score: hasScore ? { home: hs, away: as } : undefined,
+    shootout,
     minute: parseMinute(ev.status ?? comp?.status),
     status,
     winnerCode,

--- a/packages/core/src/normalize.ts
+++ b/packages/core/src/normalize.ts
@@ -17,10 +17,19 @@ export function isFinished(status: Status): boolean {
   return status === 'FT';
 }
 
-/** Compact scoreline string, e.g. "1–0" (en dash) or "vs" when unscored. */
+/**
+ * Compact scoreline string, e.g. "1–0" (en dash), or "vs" when unscored. A
+ * knockout decided on penalties appends each side's shootout score in parens —
+ * "1(3)–1(4)" — so the level regulation result still reads while showing who
+ * advanced.
+ */
 export function scoreline(match: Match): string {
   if (!match.score) return 'vs';
-  return `${match.score.home}–${match.score.away}`;
+  const { home, away } = match.score;
+  if (match.shootout) {
+    return `${home}(${match.shootout.home})–${away}(${match.shootout.away})`;
+  }
+  return `${home}–${away}`;
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -58,6 +58,13 @@ export interface Match {
   away: Team;
   /** Present once the match is no longer purely SCHEDULED. */
   score?: { home: number; away: number };
+  /**
+   * Penalty-shootout score for a knockout decided on penalties (ESPN
+   * `competitor.shootoutScore`; status detail "FT-Pens"). Present ONLY for
+   * shootout matches — `score` stays the level regulation/extra-time result, and
+   * `scoreline` renders e.g. "1(3)–1(4)". Live-only, never in the bundle.
+   */
+  shootout?: { home: number; away: number };
   /** Live match minute when in progress. */
   minute?: number;
   status: Status;

--- a/packages/core/test/espn.test.ts
+++ b/packages/core/test/espn.test.ts
@@ -131,6 +131,31 @@ describe('mapEspnEvent', () => {
     expect(m.winnerCode).toBe('NED');
   });
 
+  it('maps the penalty shootout score when ESPN sends shootoutScore on both sides', () => {
+    const pens = {
+      ...finished,
+      competitions: [
+        {
+          ...finished.competitions[0],
+          competitors: [
+            // ESPN sends shootoutScore as a NUMBER, score as a string.
+            { homeAway: 'home', score: '1', shootoutScore: 3, team: { abbreviation: 'GER', displayName: 'Germany' } },
+            { homeAway: 'away', score: '1', shootoutScore: 4, winner: true, team: { abbreviation: 'PAR', displayName: 'Paraguay' } },
+          ],
+        },
+      ],
+    };
+    const m = mapEspnEvent(pens as never, { groupByTeam: GROUP_MAP });
+    expect(m.score).toEqual({ home: 1, away: 1 }); // regulation result preserved
+    expect(m.shootout).toEqual({ home: 3, away: 4 });
+    expect(m.winnerCode).toBe('PAR');
+  });
+
+  it('leaves shootout undefined for a regular finished match (no phantom parens)', () => {
+    const m = mapEspnEvent(finished as never, { groupByTeam: GROUP_MAP });
+    expect(m.shootout).toBeUndefined();
+  });
+
   it('maps a knockout fixture from the slug, with no group letter', () => {
     const m = mapEspnEvent(knockout as never, { groupByTeam: GROUP_MAP });
     expect(m.stage).toBe('R16');

--- a/packages/core/test/espn.test.ts
+++ b/packages/core/test/espn.test.ts
@@ -156,6 +156,26 @@ describe('mapEspnEvent', () => {
     expect(m.shootout).toBeUndefined();
   });
 
+  it('never sets shootout without a regulation score (no impossible { score: undefined, shootout })', () => {
+    // Defensive: shootoutScore present but score absent → both omitted, so the
+    // structured payload (--json / MCP data) can't surface an inconsistent state.
+    const orphan = {
+      ...finished,
+      competitions: [
+        {
+          ...finished.competitions[0],
+          competitors: [
+            { homeAway: 'home', score: '', shootoutScore: 3, team: { abbreviation: 'GER', displayName: 'Germany' } },
+            { homeAway: 'away', score: '', shootoutScore: 4, team: { abbreviation: 'PAR', displayName: 'Paraguay' } },
+          ],
+        },
+      ],
+    };
+    const m = mapEspnEvent(orphan as never, { groupByTeam: GROUP_MAP });
+    expect(m.score).toBeUndefined();
+    expect(m.shootout).toBeUndefined();
+  });
+
   it('maps a knockout fixture from the slug, with no group letter', () => {
     const m = mapEspnEvent(knockout as never, { groupByTeam: GROUP_MAP });
     expect(m.stage).toBe('R16');

--- a/packages/core/test/normalize.test.ts
+++ b/packages/core/test/normalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { matchLocation, stageLabel, type Match } from '../src/index';
+import { matchLocation, scoreline, stageLabel, type Match } from '../src/index';
 
 function match(over: Partial<Match> = {}): Match {
   return {
@@ -34,6 +34,30 @@ describe('matchLocation', () => {
     expect(matchLocation(match({ city: 'Toronto', country: undefined }))).toBe(
       'Estadio Banorte, Toronto',
     );
+  });
+});
+
+describe('scoreline', () => {
+  it('renders "vs" when the match is unscored', () => {
+    expect(scoreline(match())).toBe('vs');
+  });
+
+  it('renders a plain scoreline with an en dash', () => {
+    expect(scoreline(match({ status: 'FT', score: { home: 2, away: 1 } }))).toBe('2–1');
+  });
+
+  it('appends each side\'s shootout score for a penalty knockout', () => {
+    expect(
+      scoreline(
+        match({
+          stage: 'R32',
+          group: undefined,
+          status: 'FT',
+          score: { home: 1, away: 1 },
+          shootout: { home: 3, away: 4 },
+        }),
+      ),
+    ).toBe('1(3)–1(4)');
   });
 });
 

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -149,6 +149,20 @@ describe('toolGetToday', () => {
     expect(data.count).toBeGreaterThan(0); // static fixtures still present
     expect(r.text).toContain('Live scores unavailable'); // and it says so
   });
+
+  it('renders a penalty shootout score in the day card (surface inherits scoreline)', async () => {
+    // FT match (not "live"), so today — not get_live — is the surface that shows it.
+    const pens = liveMatch({
+      status: 'FT',
+      minute: undefined,
+      score: { home: 1, away: 1 },
+      shootout: { home: 3, away: 4 },
+    });
+    const r = await toolGetToday({ date: '2026-06-11', tz: 'UTC', adapter: fakeAdapter({ byDate: [pens] }) });
+    expect(r.text).toContain('1(3)–1(4)');
+    const opener = (r.data as { matches: Match[] }).matches.find((m) => m.id === '760415');
+    expect(opener?.shootout).toEqual({ home: 3, away: 4 });
+  });
 });
 
 describe('toolGetNextFixture (live-resolved knockout)', () => {

--- a/scripts/release-qa.sh
+++ b/scripts/release-qa.sh
@@ -123,7 +123,14 @@ fi
 # formatter (core `formatShareSnippet`, which every card routes through `scoreline`)
 # so this regression class is proven even when the live feed degrades to SKIP above
 # — the exact gap that hid the live penalty render in one review env. (v0.8.10)
-if [ -f "$CORE_DIST" ]; then
+# NOTE: this renders the LOCAL repo core formatter (what's about to ship via the
+# normal `pnpm -r build && pnpm release:qa` path). In `CLI=claudinho` mode you're
+# testing an already-published global, whose bundled formatter we can't import —
+# so SKIP rather than claim a PASS that doesn't reflect the global install.
+if [ -n "${CLI:-}" ]; then
+  printf '  \033[33m⚠ SKIP\033[0m  penalty render check (CLI override tests a global install; tripwire renders the local core formatter)\n'
+  SKIP=$((SKIP+1))
+elif [ -f "$CORE_DIST" ]; then
   PENS="$(node --input-type=module -e "
 import { formatShareSnippet } from 'file://$CORE_DIST';
 const m = { id:'pk', stage:'R32', kickoff:'2026-06-30T18:00Z', venue:'X',

--- a/scripts/release-qa.sh
+++ b/scripts/release-qa.sh
@@ -23,6 +23,7 @@ set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DIST="$ROOT/packages/cli/dist/index.js"
+CORE_DIST="$ROOT/packages/core/dist/index.js"
 export CLAUDINHO_COMPETITION="${CLAUDINHO_COMPETITION:-fifa.world}"
 LANGS=(en es pt fr)
 TEAM="${TEAM:-MEX}"
@@ -115,6 +116,27 @@ else
   grep -qi "not affiliated with FIFA" <<<"$SBC" \
     && check ok  "share bracket --style compact carries the disclaimer" \
     || check no  "share bracket --style compact carries the disclaimer"
+fi
+
+# T5 — DETERMINISTIC, feed-independent: a knockout decided on penalties renders the
+# shootout score "1(3)–1(4)". Run on a synthetic fixture through the real share
+# formatter (core `formatShareSnippet`, which every card routes through `scoreline`)
+# so this regression class is proven even when the live feed degrades to SKIP above
+# — the exact gap that hid the live penalty render in one review env. (v0.8.10)
+if [ -f "$CORE_DIST" ]; then
+  PENS="$(node --input-type=module -e "
+import { formatShareSnippet } from 'file://$CORE_DIST';
+const m = { id:'pk', stage:'R32', kickoff:'2026-06-30T18:00Z', venue:'X',
+  home:{code:'GER',name:'Germany',flag:'🇩🇪'}, away:{code:'PAR',name:'Paraguay',flag:'🇵🇾'},
+  status:'FT', score:{home:1,away:1}, shootout:{home:3,away:4}, updatedAt:'2026-06-30T21:00Z' };
+process.stdout.write(formatShareSnippet({ title:'pens', matches:[m] }, {}));
+" 2>/dev/null)"
+  grep -q "1(3)–1(4)" <<<"$PENS" \
+    && check ok  "penalty shootout renders 1(3)–1(4) (deterministic, feed-independent)" \
+    || check no  "penalty shootout renders 1(3)–1(4) (deterministic, feed-independent)"
+else
+  printf '  \033[33m⚠ SKIP\033[0m  penalty render check (core dist not built — run pnpm -r build)\n'
+  SKIP=$((SKIP+1))
 fi
 
 echo


### PR DESCRIPTION
## The gap (reported by Arturo)
Today's R32 ties went to penalties, but `claudinho today` showed only the level regulation result — `🇩🇪 Germany 1–1 Paraguay 🇵🇾 FT` — with no indication Paraguay advanced. Now: `🇩🇪 Germany 1(3)–1(4) Paraguay 🇵🇾 FT`.

## Fix (single chokepoint → every surface)
ESPN carries `competitor.shootoutScore` (a number) on **both** sides only for shootout matches (status `FT-Pens`; absent on regular FT).
- **Model:** `Match.shootout? { home, away }` — live-only; regulation `score` preserved.
- **Adapter:** maps `shootoutScore` → `shootout`, gated on **both present AND `hasScore`** (no phantom parens; no impossible `{ score: undefined, shootout }` in structured data — review fix).
- **`scoreline()`:** renders `1(3)–1(4)` when `shootout` is set. Every surface routes through it (CLI today/live/match/next, statusline, hook, bracket, share, MCP), so all inherit it. `winnerCode` advancement unchanged.

## Coverage
- Core: adapter parse (penalty / regular-omits / orphan-shootout-rejected) + `scoreline` (plain / vs / pens).
- **Surface-level (one layer above core):** CLI `matchLine` + MCP `today` render tests asserting `1(3)–1(4)`.
- **`release:qa`:** a deterministic, feed-independent penalty tripwire (renders a synthetic fixture through `formatShareSnippet`); skips in `CLI=claudinho` global mode.
- Verified end-to-end on the **real ESPN feed** (GER 1(3)–1(4) PAR, NED 1(2)–1(3) MAR; regular FT stays clean) and via `claudinho today 2026-06-29`.

`core 205 / cli 204 / mcp 70`, lint + release:qa (5/5) green. **Not MCP-affecting** → no Registry republish.

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>