### PR TITLE
fix(core): Polymarket markets for knockout matches (day-boundary slug + knockout team resolution)

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -22,6 +22,7 @@ import {
   marketBlock,
   marketFixtureForTeam,
   marketLine,
+  marketSignalRendersFor,
   marketRelevant,
   matchFlavor,
   matchLocation,
@@ -155,7 +156,12 @@ async function reliableMarketSignals(
   if (relevant.length === 0) return new Map();
   const raw = await marketSignalsFor(ctx, relevant, DEFAULT_ON_MARKET_OPTS);
   const out = new Map<string, MarketSignal>();
-  for (const [id, s] of raw) if (isReliableMarketSignal(s, { now })) out.set(id, s);
+  for (const [id, s] of raw) {
+    const m = relevant.find((x) => x.id === id);
+    // Re-check against the fixture being shown: a cached signal must not render
+    // against a degraded placeholder that inherited its id (fail closed).
+    if (m && isReliableMarketSignal(s, { now }) && marketSignalRendersFor(m, s)) out.set(id, s);
+  }
   return out;
 }
 
@@ -690,9 +696,19 @@ export async function cmdMatch(id: string, ctx: Ctx): Promise<void> {
 // FIFA/Anthropic disclaimer stays localized via t('disclaimer').
 const MARKET_INFO = 'Prediction-market data is informational only.';
 
-/** Show a signal only if it maps cleanly and has a determinable favorite. */
-function marketDisplayable(sig: MarketSignal): boolean {
-  return !sig.ambiguous && sig.favorite != null && hasSaneDistribution(sig.outcomes);
+/**
+ * Show a signal only if it maps cleanly, has a determinable favorite, AND still
+ * matches the fixture being rendered — the last check (`marketSignalRendersFor`)
+ * re-validates a cached signal against the current Match so it can't print
+ * against a degraded knockout placeholder (display labels come from the Match).
+ */
+function marketDisplayable(match: Match, sig: MarketSignal): boolean {
+  return (
+    marketSignalRendersFor(match, sig) &&
+    !sig.ambiguous &&
+    sig.favorite != null &&
+    hasSaneDistribution(sig.outcomes)
+  );
 }
 
 /**
@@ -746,16 +762,17 @@ export async function cmdMarkets(
     const now = ctx.now ?? new Date();
     // Live-confirmed selection: handles extra time past the static window AND
     // early FTs inside it (the static fixture's status is forever SCHEDULED).
-    const { match: fixture } = await marketFixtureForTeam(adapterFor(ctx), code, now);
+    const { match: fixture, degraded } = await marketFixtureForTeam(adapterFor(ctx), code, now);
     const sig =
       fixture && marketRelevant(fixture, now)
         ? (await marketSignalsFor(ctx, [fixture], MARKETS_CMD_OPTS)).get(fixture.id)
         : undefined;
-    const shown = sig && marketDisplayable(sig) ? sig : undefined;
+    const shown = fixture && sig && marketDisplayable(fixture, sig) ? sig : undefined;
     if (cfg.json) {
       emitJson({
         team: code,
         matchId: fixture?.id ?? null,
+        degraded,
         informationalOnly: true,
         signal: shown ?? null,
       });
@@ -764,7 +781,8 @@ export async function cmdMarkets(
     const c = painterFor(cfg);
     out();
     if (!fixture) {
-      out(c.dim('  ' + t('next.none', { team: code })));
+      // Feed unavailable can't resolve a knockout tie — say so, vs "no fixture".
+      out(c.dim('  ' + (degraded ? t('live.degraded') : t('next.none', { team: code }))));
     } else {
       out(header(marketHeaderLine(fixture, cfg), c));
       out();
@@ -787,7 +805,7 @@ export async function cmdMarkets(
       match && marketRelevant(match, now)
         ? (await marketSignalsFor(ctx, [match], MARKETS_CMD_OPTS)).get(match.id)
         : undefined;
-    const shown = sig && marketDisplayable(sig) ? sig : undefined;
+    const shown = match && sig && marketDisplayable(match, sig) ? sig : undefined;
     if (cfg.json) {
       emitJson({ matchId: target, informationalOnly: true, signal: shown ?? null });
       return;
@@ -821,7 +839,7 @@ export async function cmdMarkets(
     .map((m) => ({ match: m, signal: signals.get(m.id) }))
     .filter(
       (r): r is { match: Match; signal: MarketSignal } =>
-        !!r.signal && marketDisplayable(r.signal),
+        !!r.signal && marketDisplayable(r.match, r.signal),
     );
 
   if (cfg.json) {
@@ -878,7 +896,10 @@ async function reliableShareSignals(
 ): Promise<Map<string, MarketSignal>> {
   const raw = await reliableMarketSignals(ctx, matches);
   const out = new Map<string, MarketSignal>();
-  for (const [id, s] of raw) if (marketDisplayable(s)) out.set(id, s);
+  for (const [id, s] of raw) {
+    const m = matches.find((x) => x.id === id);
+    if (m && marketDisplayable(m, s)) out.set(id, s);
+  }
   return out;
 }
 

--- a/packages/cli/test/knockout-surface-coverage.test.ts
+++ b/packages/cli/test/knockout-surface-coverage.test.ts
@@ -20,8 +20,8 @@
  * when the cache lacks the pairing. Both contracts are asserted at the bottom.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Match, ProviderAdapter } from '@claudinho/core';
-import { cmdBracket, cmdNext, cmdShare } from '../src/commands';
+import { FakeMarketProvider, type Match, type ProviderAdapter } from '@claudinho/core';
+import { cmdBracket, cmdMarkets, cmdNext, cmdShare } from '../src/commands';
 import type { CliConfig } from '../src/config';
 import { makeT } from '../src/i18n';
 import type { CacheState } from '../src/cache';
@@ -125,6 +125,16 @@ describe('knockout surface coverage — every team-facing CLI surface live-resol
     const t = text();
     expect(t).toContain('Mexico');
     expect(t).toContain('Ecuador');
+  });
+
+  it('`markets next <team>` resolves the opponent, not the placeholder', async () => {
+    // marketFixtureForTeam must live-resolve the KO tie (offline fake provider
+    // keeps the market fetch off the network — we only assert nation resolution).
+    await cmdMarkets('next', 'MEX', { ...ctx(), marketProvider: new FakeMarketProvider() });
+    const t = text();
+    expect(t).toContain('Mexico');
+    expect(t).toContain('Ecuador');
+    expect(t).not.toContain(PLACEHOLDER_FLAG);
   });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,6 +85,7 @@ export {
   deriveFavorite,
   favoriteStrength,
   mapsCleanly,
+  marketSignalRendersFor,
   hasSaneDistribution,
   isStaleSignal,
   isReliableMarketSignal,

--- a/packages/core/src/live.ts
+++ b/packages/core/src/live.ts
@@ -243,12 +243,13 @@ export async function marketFixtureForTeam(
   // upcoming fixture" for a team past its group stage (same root cause as
   // getNextFixtureForTeam). Fail closed to the static skeleton on a provider error.
   let fixtures = allFixtures();
+  let overlayFailed = false;
   try {
     if (adapter.fetchWindow) {
       fixtures = mergeLive(fixtures, await adapter.fetchWindow(KNOCKOUT_WINDOW_START, KNOCKOUT_WINDOW_END));
     }
   } catch {
-    // static skeleton only — a knockout team then resolves to no fixture (fail closed)
+    overlayFailed = true; // KO overlay unavailable — a knockout tie may be unresolvable
   }
   const candidate = fixturesByTeam(code, fixtures).find((m) => {
     const k = Date.parse(m.kickoff);
@@ -261,7 +262,10 @@ export async function marketFixtureForTeam(
     // Confirmed finished → the team's market story has moved on.
   }
   const next = nextFixtureForTeam(code, { from: now, fixtures });
-  return { match: next, degraded: false };
+  // When the overlay fetch failed the static skeleton can't resolve a knockout
+  // tie, so flag degraded — lets a caller say "feed unavailable" rather than the
+  // misleading "no upcoming fixture" for a team past its group stage.
+  return { match: next, degraded: overlayFailed };
 }
 
 export interface NextFixtureResult {

--- a/packages/core/src/live.ts
+++ b/packages/core/src/live.ts
@@ -238,7 +238,19 @@ export async function marketFixtureForTeam(
   now: Date = new Date(),
 ): Promise<MatchByIdResult> {
   const nowMs = now.getTime();
-  const candidate = fixturesByTeam(code).find((m) => {
+  // Overlay the live knockout window so a knockout team's fixtures RESOLVE — the
+  // bundle's KO slots are 🏳️ placeholders, so a purely static lookup answers "no
+  // upcoming fixture" for a team past its group stage (same root cause as
+  // getNextFixtureForTeam). Fail closed to the static skeleton on a provider error.
+  let fixtures = allFixtures();
+  try {
+    if (adapter.fetchWindow) {
+      fixtures = mergeLive(fixtures, await adapter.fetchWindow(KNOCKOUT_WINDOW_START, KNOCKOUT_WINDOW_END));
+    }
+  } catch {
+    // static skeleton only — a knockout team then resolves to no fixture (fail closed)
+  }
+  const candidate = fixturesByTeam(code, fixtures).find((m) => {
     const k = Date.parse(m.kickoff);
     return nowMs >= k && nowMs <= k + LIVE_WINDOW_MS + EXTRA_TIME_SLACK_MS;
   });
@@ -248,7 +260,7 @@ export async function marketFixtureForTeam(
     if (!isFinished(m.status)) return { ...r, match: m };
     // Confirmed finished → the team's market story has moved on.
   }
-  const next = nextFixtureForTeam(code, { from: now });
+  const next = nextFixtureForTeam(code, { from: now, fixtures });
   return { match: next, degraded: false };
 }
 

--- a/packages/core/src/live.ts
+++ b/packages/core/src/live.ts
@@ -15,6 +15,7 @@ import {
   nextFixtureForTeam,
 } from './schedule';
 import { rosterAtZero, type GroupStandings } from './standings';
+import { shiftUtcDate } from './time';
 import type { Match, Stage } from './types';
 import { isResolvedNation } from './bracket/placeholders';
 import { buildBracketView } from './bracket/resolve';
@@ -199,13 +200,6 @@ export async function getBracket(
   };
 }
 
-/** Shift a "YYYY-MM-DD" date by whole UTC days, returning "YYYY-MM-DD". */
-function shiftUtcDate(dateISO: string, days: number): string {
-  const [y, m, d] = dateISO.slice(0, 10).split('-').map(Number);
-  return new Date(Date.UTC(y ?? 1970, (m ?? 1) - 1, (d ?? 1) + days))
-    .toISOString()
-    .slice(0, 10);
-}
 
 export interface MatchByIdResult {
   match?: Match;

--- a/packages/core/src/markets/normalize.ts
+++ b/packages/core/src/markets/normalize.ts
@@ -98,6 +98,20 @@ export function mapsCleanly(match: Match, outcomes: MarketOutcome[]): boolean {
   return true;
 }
 
+/**
+ * Is a (possibly cached/looked-up) signal safe to RENDER for THIS fixture? A
+ * signal is keyed and stored by match id, but display labels are taken from the
+ * *current* Match — so a cached signal must be re-checked against the fixture
+ * actually being shown. The guard: same match id AND the outcomes still map to
+ * the fixture's real teams. This fails closed when a knockout slot the feed
+ * resolved earlier later degrades back to a 🏳️ placeholder (the signal's own
+ * `ambiguous` flag was decided at fetch time, against the resolved match, so it
+ * can't catch this on its own).
+ */
+export function marketSignalRendersFor(match: Match, signal: MarketSignal): boolean {
+  return signal.matchId === match.id && mapsCleanly(match, signal.outcomes);
+}
+
 /** Sanity check: ≥2 priced outcomes whose probabilities sum to ~1. */
 export function hasSaneDistribution(outcomes: MarketOutcome[]): boolean {
   const priced = outcomes.filter((o) => Number.isFinite(o.probability) && o.probability > 0);

--- a/packages/core/src/markets/polymarket.ts
+++ b/packages/core/src/markets/polymarket.ts
@@ -145,12 +145,17 @@ export class PolymarketProvider implements MarketProvider {
     options?: MarketSignalOptions,
   ): Promise<{ signal?: MarketSignal; checked: boolean }> {
     const entry = (this.opts.mapping ?? BUNDLED_MAPPING)[match.id];
-    const eventSlug = entry?.eventSlug ?? deriveEventSlug(match);
-    if (!eventSlug) return { checked: true }; // definitively unmappable → no market
+    // A hand-curated override is authoritative (single slug); otherwise try the
+    // derived candidates (UTC date, then the prior day — see deriveEventSlugs).
+    const slugs = entry?.eventSlug ? [entry.eventSlug] : deriveEventSlugs(match);
+    if (slugs.length === 0) return { checked: true }; // definitively unmappable → no market
     try {
-      const event = await this.fetchEvent(eventSlug, options?.timeoutMs);
-      const signal = event ? this.toSignal(match, eventSlug, event, options) : undefined;
-      return { signal, checked: true }; // reached the source and resolved
+      for (const slug of slugs) {
+        const event = await this.fetchEvent(slug, options?.timeoutMs);
+        const signal = event ? this.toSignal(match, slug, event, options) : undefined;
+        if (signal) return { signal, checked: true }; // first candidate that validates wins
+      }
+      return { checked: true }; // reached the source, no usable market on any candidate
     } catch {
       return { checked: false }; // provider/network error → retry, don't cache
     }
@@ -260,19 +265,36 @@ export class PolymarketProvider implements MarketProvider {
   }
 }
 
+/** Shift a "YYYY-MM-DD" date by whole days (UTC), returning "YYYY-MM-DD". */
+function shiftDay(date: string, days: number): string {
+  const [y, m, d] = date.split('-').map(Number);
+  return new Date(Date.UTC(y ?? 1970, (m ?? 1) - 1, (d ?? 1) + days)).toISOString().slice(0, 10);
+}
+
 /**
- * Derive the Gamma event slug from a fixture: `fifwc-{home}-{away}-{utcDate}`.
- * Returns undefined for placeholder/unresolved fixtures (non-3-letter or TBD
- * codes) so we never query garbage slugs.
+ * Candidate Gamma event slugs for a fixture: `fifwc-{home}-{away}-{date}`.
+ * Returns [] for placeholder/unresolved fixtures (non-3-letter or TBD codes) so
+ * we never query garbage slugs.
+ *
+ * Polymarket slugs a match by its HOST-LOCAL date, which for the Americas-hosted
+ * 2026 WC is the UTC date OR the day before — a late-evening kickoff crosses into
+ * the next UTC day (e.g. MEX–ECU at 01:00Z is Jun 30 in the Americas, slugged
+ * `…-06-30`, not `…-07-01`). The Americas are always behind UTC, so we only need
+ * the UTC date and the prior day. We try the UTC date first; `toSignal`'s
+ * kickoff line-up + exact-slug checks reject a wrong-day event, so the prior-day
+ * fallback stays fail-closed.
  */
-function deriveEventSlug(match: Match): string | undefined {
+function deriveEventSlugs(match: Match): string[] {
   const home = match.home.code.toLowerCase();
   const away = match.away.code.toLowerCase();
-  if (home === away || home === 'tbd' || away === 'tbd') return undefined;
-  if (!/^[a-z]{3}$/.test(home) || !/^[a-z]{3}$/.test(away)) return undefined;
-  const date = match.kickoff.slice(0, 10);
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return undefined;
-  return `fifwc-${home}-${away}-${date}`;
+  if (home === away || home === 'tbd' || away === 'tbd') return [];
+  if (!/^[a-z]{3}$/.test(home) || !/^[a-z]{3}$/.test(away)) return [];
+  const utcDate = match.kickoff.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(utcDate)) return [];
+  return [
+    `fifwc-${home}-${away}-${utcDate}`,
+    `fifwc-${home}-${away}-${shiftDay(utcDate, -1)}`,
+  ];
 }
 
 /** Last dash-segment of a market slug — the outcome token (`mex`/`draw`/`rsa`). */

--- a/packages/core/src/markets/polymarket.ts
+++ b/packages/core/src/markets/polymarket.ts
@@ -20,6 +20,7 @@
  * requested slug, line up on kickoff, expose the right moneyline markets, and
  * resolve in regular time — otherwise no signal is produced.
  */
+import { shiftUtcDate } from '../time';
 import type { Match } from '../types';
 import mappingJson from './mapping.2026.json';
 import { buildMarketSignal } from './normalize';
@@ -265,12 +266,6 @@ export class PolymarketProvider implements MarketProvider {
   }
 }
 
-/** Shift a "YYYY-MM-DD" date by whole days (UTC), returning "YYYY-MM-DD". */
-function shiftDay(date: string, days: number): string {
-  const [y, m, d] = date.split('-').map(Number);
-  return new Date(Date.UTC(y ?? 1970, (m ?? 1) - 1, (d ?? 1) + days)).toISOString().slice(0, 10);
-}
-
 /**
  * Candidate Gamma event slugs for a fixture: `fifwc-{home}-{away}-{date}`.
  * Returns [] for placeholder/unresolved fixtures (non-3-letter or TBD codes) so
@@ -293,7 +288,7 @@ function deriveEventSlugs(match: Match): string[] {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(utcDate)) return [];
   return [
     `fifwc-${home}-${away}-${utcDate}`,
-    `fifwc-${home}-${away}-${shiftDay(utcDate, -1)}`,
+    `fifwc-${home}-${away}-${shiftUtcDate(utcDate, -1)}`,
   ];
 }
 

--- a/packages/core/src/time.ts
+++ b/packages/core/src/time.ts
@@ -120,3 +120,15 @@ export function localDate(iso: string, tz?: string): string {
     timeZone: zone,
   }).format(new Date(iso));
 }
+
+/**
+ * Shift a date by whole **UTC** days, returning `YYYY-MM-DD`. Accepts a full ISO
+ * timestamp or a bare date (only the date part is read). Used to build ±1-day
+ * fetch windows (live.ts) and adjacent-day market slugs (markets/polymarket.ts).
+ */
+export function shiftUtcDate(dateISO: string, days: number): string {
+  const [y, m, d] = dateISO.slice(0, 10).split('-').map(Number);
+  return new Date(Date.UTC(y ?? 1970, (m ?? 1) - 1, (d ?? 1) + days))
+    .toISOString()
+    .slice(0, 10);
+}

--- a/packages/core/test/markets.test.ts
+++ b/packages/core/test/markets.test.ts
@@ -18,6 +18,7 @@ import {
   marketFavoriteText,
   marketLine,
   marketProbabilityText,
+  marketSignalRendersFor,
   normalizeOutcomes,
 } from '../src/index';
 
@@ -139,6 +140,30 @@ describe('mapsCleanly / ambiguity', () => {
     ];
     expect(mapsCleanly(match(), withOther)).toBe(false);
     expect(build(withOther).ambiguous).toBe(true);
+  });
+});
+
+describe('marketSignalRendersFor (re-check a cached signal vs the rendered fixture)', () => {
+  const sig = build(hda(0.56, 0.25, 0.19)); // matchId 760415, MEX/RSA outcomes
+
+  it('renders for the fixture it was built for', () => {
+    expect(marketSignalRendersFor(match(), sig)).toBe(true);
+  });
+
+  it('does NOT render against a degraded placeholder (same id, unresolved teams)', () => {
+    // The bundle KO slot keeps the id but degrades to placeholder codes/flags —
+    // a cached MEX/RSA signal must not print "Group A Winner 56% · …".
+    const placeholder = match({
+      stage: 'R32',
+      group: undefined,
+      home: { code: '1A', name: 'Group A Winner', flag: '🏳️' },
+      away: { code: '2B', name: 'Group B Runner-up', flag: '🏳️' },
+    });
+    expect(marketSignalRendersFor(placeholder, sig)).toBe(false);
+  });
+
+  it('does NOT render when the signal is for a different match id', () => {
+    expect(marketSignalRendersFor(match({ id: '999999' }), sig)).toBe(false);
   });
 });
 

--- a/packages/core/test/matchday.test.ts
+++ b/packages/core/test/matchday.test.ts
@@ -217,4 +217,23 @@ describe('marketFixtureForTeam (live-confirmed selection)', () => {
     const r = await marketFixtureForTeam(adapterReturning([]), team, before);
     expect(r.match?.id).toBe(opener.id);
   });
+
+  it('resolves a knockout team via the live overlay (not the static skeleton)', async () => {
+    // A team past its group stage has only 🏳️ placeholder KO slots in the bundle,
+    // so a static lookup answers "no fixture". The overlay carries the resolved tie.
+    const r32: Match = {
+      id: '760491',
+      stage: 'R32',
+      kickoff: '2026-07-01T01:00Z',
+      venue: 'X',
+      home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+      away: { code: 'ECU', name: 'Ecuador', flag: '🇪🇨' },
+      status: 'SCHEDULED',
+      updatedAt: '2026-06-30T00:00Z',
+    };
+    const before = new Date('2026-06-30T12:00:00Z'); // group stage done, before the R32
+    const r = await marketFixtureForTeam(adapterReturning([r32]), 'MEX', before);
+    expect(r.match?.id).toBe('760491');
+    expect(r.match?.away.code).toBe('ECU');
+  });
 });

--- a/packages/core/test/matchday.test.ts
+++ b/packages/core/test/matchday.test.ts
@@ -236,4 +236,13 @@ describe('marketFixtureForTeam (live-confirmed selection)', () => {
     expect(r.match?.id).toBe('760491');
     expect(r.match?.away.code).toBe('ECU');
   });
+
+  it('flags degraded when the overlay fails and a knockout tie cannot resolve', async () => {
+    // MEX past its group stage, ESPN down → no static knockout fixture. Honest
+    // "feed unavailable", not a misleading "no upcoming fixture".
+    const before = new Date('2026-06-30T12:00:00Z');
+    const r = await marketFixtureForTeam(adapterReturning('throw'), 'MEX', before);
+    expect(r.match).toBeUndefined();
+    expect(r.degraded).toBe(true);
+  });
 });

--- a/packages/core/test/polymarket.test.ts
+++ b/packages/core/test/polymarket.test.ts
@@ -133,6 +133,41 @@ describe('PolymarketProvider — slug derivation', () => {
     // Without the override, the derived slug wouldn't match the served event.
     expect(await derived(fetchFor(custom, event({ slug: custom }))).findSignal(match())).toBeUndefined();
   });
+
+  it('resolves a day-boundary kickoff via the prior-day slug (UTC date misses)', async () => {
+    // MEX–ECU kicks off 01:00Z = Jun 30 evening in the Americas; Polymarket slugs
+    // it `…-06-30`, but the UTC date is 07-01. The provider must try the UTC date
+    // (miss) then the prior day (hit). Regression for the missing-market bug.
+    const ko = match({
+      id: '760491',
+      stage: 'R32',
+      group: undefined,
+      kickoff: '2026-07-01T01:00Z',
+      home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+      away: { code: 'ECU', name: 'Ecuador', flag: '🇪🇨' },
+    });
+    const upd = '2026-07-01T00:25:00Z';
+    const ev = event({
+      slug: 'fifwc-mex-ecu-2026-06-30',
+      title: 'Mexico vs. Ecuador',
+      startTime: '2026-07-01T01:00:00Z',
+      updatedAt: upd,
+      markets: [
+        market('mex', 'Mexico', 0.45, { updatedAt: upd }),
+        market('draw', 'Draw (regular time)', 0.32, { updatedAt: upd }),
+        market('ecu', 'Ecuador', 0.23, { updatedAt: upd }),
+      ],
+    });
+    // Only the prior-day slug serves the event; the UTC-date slug returns [].
+    const p = new PolymarketProvider({
+      fetchImpl: fetchFor('fifwc-mex-ecu-2026-06-30', ev),
+      now: new Date('2026-07-01T00:30:00Z'),
+    });
+    const sig = await p.findSignal(ko);
+    expect(sig?.source).toBe('polymarket');
+    expect(sig?.outcomes.map((o) => o.kind)).toEqual(['home', 'draw', 'away']);
+    expect(sig?.favorite).toMatchObject({ kind: 'home', teamCode: 'MEX' });
+  });
 });
 
 describe('PolymarketProvider — fail-closed validation', () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -30,6 +30,7 @@ import {
   marketBlock,
   marketFixtureForTeam,
   marketRelevant,
+  marketSignalRendersFor,
   type Match,
   type MarketProvider,
   type MarketSignal,
@@ -70,9 +71,19 @@ function resolveMarketProvider(args: CommonOpts): MarketProvider {
   return args.marketProvider ?? makeMarketProvider();
 }
 
-/** Show a signal only if it maps cleanly and has a determinable favorite. */
-function marketDisplayable(sig: MarketSignal): boolean {
-  return !sig.ambiguous && sig.favorite != null && hasSaneDistribution(sig.outcomes);
+/**
+ * Show a signal only if it maps cleanly, has a determinable favorite, AND still
+ * matches the fixture being rendered — the last check (`marketSignalRendersFor`)
+ * re-validates a cached signal against the current Match so it can't print
+ * against a degraded knockout placeholder (display labels come from the Match).
+ */
+function marketDisplayable(match: Match, sig: MarketSignal): boolean {
+  return (
+    marketSignalRendersFor(match, sig) &&
+    !sig.ambiguous &&
+    sig.favorite != null &&
+    hasSaneDistribution(sig.outcomes)
+  );
 }
 
 /**
@@ -195,7 +206,9 @@ async function reliableMarketData(
   const out: Record<string, ReturnType<typeof marketData>> = {};
   for (const m of relevant) {
     const s = signals.get(m.id);
-    if (s && isReliableMarketSignal(s, { now })) out[m.id] = marketData(s);
+    if (s && isReliableMarketSignal(s, { now }) && marketSignalRendersFor(m, s)) {
+      out[m.id] = marketData(s);
+    }
   }
   return Object.keys(out).length > 0 ? out : undefined;
 }
@@ -275,7 +288,7 @@ export async function toolGetMatch(
   let marketSignal: MarketSignal | undefined;
   if (marketsEnabled() && marketRelevant(match, now)) {
     const s = (await cachedMarketSignals(args, [match])).get(match.id);
-    if (s && isReliableMarketSignal(s, { now })) marketSignal = s;
+    if (s && isReliableMarketSignal(s, { now }) && marketSignalRendersFor(match, s)) marketSignal = s;
   }
   const base = matchLine(match, opts);
   let text = marketSignal ? `${base}\n${marketBlock(marketSignal, match).join('\n')}` : base;
@@ -419,7 +432,7 @@ export async function toolGetMarketSignal(
     const { match } = await getMatchById(resolveAdapter(args), args.matchId);
     const relevant = match ? marketRelevant(match, now) : false;
     const sig = match && relevant ? await getMarketSignal(provider, match) : undefined;
-    const shown = match && sig && marketDisplayable(sig) ? sig : undefined;
+    const shown = match && sig && marketDisplayable(match, sig) ? sig : undefined;
     const text = !match
       ? `No match found with id ${args.matchId}.`
       : shown
@@ -442,12 +455,14 @@ export async function toolGetMarketSignal(
     const code = args.team.toUpperCase();
     // Live-confirmed selection: handles extra time past the static window AND
     // early FTs inside it (the static fixture's status is forever SCHEDULED).
-    const { match: fixture } = await marketFixtureForTeam(resolveAdapter(args), code, now);
+    const { match: fixture, degraded } = await marketFixtureForTeam(resolveAdapter(args), code, now);
     const relevant = fixture ? marketRelevant(fixture, now) : false;
     const sig = fixture && relevant ? await getMarketSignal(provider, fixture) : undefined;
-    const shown = fixture && sig && marketDisplayable(sig) ? sig : undefined;
+    const shown = fixture && sig && marketDisplayable(fixture, sig) ? sig : undefined;
     const text = !fixture
-      ? `No upcoming fixture found for ${code}.`
+      ? degraded
+        ? `Live feed unavailable — can't resolve ${code}'s next fixture right now.`
+        : `No upcoming fixture found for ${code}.`
       : shown
         ? marketText(fixture, shown, args)
         : noSignalText(fixture, args, now);
@@ -456,6 +471,7 @@ export async function toolGetMarketSignal(
       data: {
         team: code,
         matchId: fixture?.id ?? null,
+        degraded,
         informationalOnly: true,
         signal: shown ? marketData(shown) : null,
       },
@@ -471,7 +487,7 @@ export async function toolGetMarketSignal(
     .map((m) => ({ match: m, signal: signals.get(m.id) }))
     .filter(
       (r): r is { match: Match; signal: MarketSignal } =>
-        !!r.signal && marketDisplayable(r.signal),
+        !!r.signal && marketDisplayable(r.match, r.signal),
     );
   const text = shown.length
     ? `Market signals on ${date}:\n${shown
@@ -501,7 +517,7 @@ async function reliableSignalMap(
   const out = new Map<string, MarketSignal>();
   for (const m of relevant) {
     const s = signals.get(m.id);
-    if (s && isReliableMarketSignal(s, { now }) && marketDisplayable(s)) out.set(m.id, s);
+    if (s && isReliableMarketSignal(s, { now }) && marketDisplayable(m, s)) out.set(m.id, s);
   }
   return out;
 }

--- a/packages/mcp/test/knockout-surface-coverage.test.ts
+++ b/packages/mcp/test/knockout-surface-coverage.test.ts
@@ -10,8 +10,13 @@
  * `.cursor/rules/surface-parity.mdc` and AGENTS.md "Knockout surfaces live-resolve".
  */
 import { describe, expect, it } from 'vitest';
-import type { Match, ProviderAdapter } from '@claudinho/core';
-import { toolGetBracket, toolGetNextFixture, toolGetShareSnippet } from '../src/tools';
+import { FakeMarketProvider, type Match, type ProviderAdapter } from '@claudinho/core';
+import {
+  toolGetBracket,
+  toolGetMarketSignal,
+  toolGetNextFixture,
+  toolGetShareSnippet,
+} from '../src/tools';
 
 const RESOLVED_R32_ID = '760486'; // bundle: "Group A 2nd" vs "Group B 2nd" (both 🏳️)
 function r32MexEcu(): Match {
@@ -73,5 +78,20 @@ describe('knockout surface coverage — every team-facing MCP tool live-resolves
     });
     expect(r.text).toContain('Mexico');
     expect(r.text).toContain('Ecuador');
+  });
+
+  it('get_market_signal { team } resolves the opponent, not the placeholder', async () => {
+    // marketFixtureForTeam must live-resolve the KO tie (offline fake provider
+    // keeps the market fetch off the network — we only assert nation resolution).
+    const r = await toolGetMarketSignal({
+      team: 'MEX',
+      now: KNOCKOUT_NOW,
+      adapter: overlayAdapter,
+      marketProvider: new FakeMarketProvider(),
+    });
+    expect(r.text).toContain('Mexico');
+    expect(r.text).toContain('Ecuador');
+    expect(r.text).not.toContain(PLACEHOLDER_FLAG);
+    expect((r.data as { matchId: string | null }).matchId).toBe(RESOLVED_R32_ID);
   });
 });


### PR DESCRIPTION
Prediction-market signals through the knockouts. Market-fixes-only (rebased onto main; the MCP README lives in #56). Verified on the live feed.

## 1. Day-boundary slug (the `today`/`match` symptom Arturo reported)
Slug used `match.kickoff.slice(0,10)` (UTC date). 🇲🇽 MEX–ECU at `01:00Z` = Jun 30 in the Americas → Polymarket slugs it `…-06-30`, not `…-07-01` → missed → no market. `deriveEventSlugs` now tries the UTC date + prior day; first candidate passing the existing fail-closed validation wins.

## 2. Knockout team resolution (`markets next MEX`)
`marketFixtureForTeam` read the static skeleton (placeholder KO slots) → "no upcoming fixture". Now overlays the live KO window before selection.

## Review round (two reviewers) — all addressed
- **P1 (fail-closed, blocker):** a cached signal is keyed by id but display labels come from the current Match, so a degraded knockout placeholder could print `Group A Winner 43% · …`. New core `marketSignalRendersFor(match, signal)` (matchId + mapsCleanly) re-checks every display gate (CLI `marketDisplayable`/`reliableMarketSignals`/`reliableShareSignals`; MCP `marketDisplayable` + the `isReliableMarketSignal` sites). Fails closed; happy path unchanged.
- **P2 (honesty):** `marketFixtureForTeam` now propagates `degraded` on overlay-fetch failure; `markets next` shows the localized feed-degraded notice, MCP returns `degraded` + a feed-unavailable message.
- **P3** (MCP README network line) → fixed in #56.
- **P3 nits:** `shiftUtcDate` hoisted to `time.ts` (was duplicated as `shiftDay`); the markets team surface added to the CLI + MCP knockout-surface-coverage guards.

## Result
`today` / `markets next MEX` → **Mexico 43% · Draw 33% · Ecuador 23%**. Tests: boundary slug, knockout resolution, `marketSignalRendersFor` (renders/placeholder-suppressed/wrong-id), degraded-knockout path, markets in the coverage guard. `core 211 / cli 205 / mcp 71`, lint + release:qa (5/5) green. **Not MCP-affecting** → no Registry republish.

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>