### PR TITLE
test(markets): guard against a cached signal leaking onto a degraded placeholder

### DIFF
--- a/packages/cli/test/market-degraded.test.ts
+++ b/packages/cli/test/market-degraded.test.ts
@@ -1,0 +1,130 @@
+/**
+ * MARKET-GATE DEGRADED GUARD (CLI) — review-discipline rule 11. A market signal is
+ * cached by match id, but display labels come from the *current* `Match`. When the
+ * live feed degrades and a knockout slot falls back to the bundle's 🏳️ placeholder
+ * (SAME id, unresolved teams), a cached MEX/ECU signal must NOT print as
+ * "Group A Winner 45% · …" — the fail-closed violation reviewers caught in 0.8.12.
+ *
+ * The shipped fix gates every render through core `marketSignalRendersFor(match,
+ * signal)`. The unit test covers the predicate; THIS reconstructs the adverse
+ * cache state (a resolved-then-cached signal + a degraded fixture sharing its id)
+ * and drives the real CLI entry points end-to-end. Pairs with the resolved-path
+ * `knockout-surface-coverage.test.ts`; this is its degraded twin.
+ */
+import {
+  buildMarketSignal,
+  FakeMarketProvider,
+  type Match,
+  type MarketSignal,
+  normalizeOutcomes,
+  type ProviderAdapter,
+} from '@claudinho/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cmdMarkets, cmdToday } from '../src/commands';
+import type { CliConfig } from '../src/config';
+import { makeT } from '../src/i18n';
+
+const KO_ID = '760486'; // the canonical fake R32 tie used across coverage tests
+const KICK = '2026-06-30T18:00Z';
+const RENDER_NOW = new Date('2026-06-30T12:00:00Z'); // pre-kickoff → market-relevant
+
+function mexEcu(over: Partial<Match> = {}): Match {
+  return {
+    id: KO_ID,
+    stage: 'R32',
+    kickoff: KICK,
+    venue: 'SoFi Stadium',
+    home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+    away: { code: 'ECU', name: 'Ecuador', flag: '🇪🇨' },
+    status: 'SCHEDULED',
+    updatedAt: '2026-06-30T00:00Z',
+    ...over,
+  };
+}
+
+/** The bundle placeholder the feed degrades back to — same id, unresolved teams. */
+function placeholder(): Match {
+  return mexEcu({
+    home: { code: '1A', name: 'Group A Winner', flag: '🏳️' },
+    away: { code: '2B', name: 'Group B Runner-up', flag: '🏳️' },
+  });
+}
+
+/** A signal cached while the fixture WAS resolved: matchId KO_ID, MEX/ECU outcomes. */
+function cachedSignal(): MarketSignal {
+  return buildMarketSignal({
+    match: mexEcu(),
+    source: 'fake',
+    asOf: '2026-06-30T11:55Z',
+    outcomes: normalizeOutcomes([
+      { kind: 'home', teamCode: 'MEX', label: 'Mexico', probability: 0.45 },
+      { kind: 'draw', label: 'Draw', probability: 0.32 },
+      { kind: 'away', teamCode: 'ECU', label: 'Ecuador', probability: 0.23 },
+    ]),
+    liquidity: 500_000,
+    now: new Date('2026-06-30T11:55Z'),
+  });
+}
+
+const provider = () => new FakeMarketProvider({ signals: { [KO_ID]: cachedSignal() } });
+
+function adapterFor(window: Match[]): ProviderAdapter {
+  return {
+    name: 'espn',
+    capabilities: { push: false, latencyHintSec: 0 },
+    async fetchByDate() {
+      return window;
+    },
+    async fetchLive() {
+      return [];
+    },
+    async fetchWindow() {
+      return window;
+    },
+  };
+}
+
+function cfg(over: Partial<CliConfig> = {}): CliConfig {
+  return { lang: 'en', tz: 'UTC', json: false, color: false, source: 'espn', flavor: 'off', ...over };
+}
+const ctx = (window: Match[]) => ({
+  cfg: cfg(),
+  t: makeT('en'),
+  adapter: adapterFor(window),
+  marketProvider: provider(),
+  now: RENDER_NOW,
+});
+
+const outSpy = vi.spyOn(process.stdout, 'write');
+let writes: string[] = [];
+beforeEach(() => {
+  writes = [];
+  outSpy.mockImplementation((c: unknown) => {
+    writes.push(String(c));
+    return true;
+  });
+});
+afterEach(() => outSpy.mockReset());
+const text = () => writes.join('');
+
+describe('CLI market gate — cached signal must not render against a degraded placeholder (rule 11)', () => {
+  it('today: SUPPRESSES the inherited market when the fixture degraded to a placeholder', async () => {
+    await cmdToday('2026-06-30', ctx([placeholder()]));
+    const o = text();
+    expect(o).toContain('Group A Winner'); // the placeholder fixture itself still renders
+    expect(o).not.toContain('45%'); // its inherited market percentages do NOT leak
+    expect(o).not.toContain('32%');
+  });
+
+  it('today: SHOWS the market when the fixture is resolved (positive control)', async () => {
+    await cmdToday('2026-06-30', ctx([mexEcu()]));
+    const o = text();
+    expect(o).toContain('Mexico');
+    expect(o).toContain('45%'); // proves the signal WAS a live candidate, not gated for another reason
+  });
+
+  it('markets <date>: drops the mismatched signal from the listing', async () => {
+    await cmdMarkets('2026-06-30', undefined, ctx([placeholder()]));
+    expect(text()).not.toContain('45%');
+  });
+});

--- a/packages/cli/test/market-degraded.test.ts
+++ b/packages/cli/test/market-degraded.test.ts
@@ -42,11 +42,14 @@ function mexEcu(over: Partial<Match> = {}): Match {
   };
 }
 
-/** The bundle placeholder the feed degrades back to — same id, unresolved teams. */
+/**
+ * The bundle placeholder the feed degrades back to — same id, unresolved teams.
+ * Mirrors the real bundled slot 760486 (`2A`/`2B`, "Group A/B 2nd Place", 🏳️).
+ */
 function placeholder(): Match {
   return mexEcu({
-    home: { code: '1A', name: 'Group A Winner', flag: '🏳️' },
-    away: { code: '2B', name: 'Group B Runner-up', flag: '🏳️' },
+    home: { code: '2A', name: 'Group A 2nd Place', flag: '🏳️' },
+    away: { code: '2B', name: 'Group B 2nd Place', flag: '🏳️' },
   });
 }
 
@@ -111,7 +114,7 @@ describe('CLI market gate — cached signal must not render against a degraded p
   it('today: SUPPRESSES the inherited market when the fixture degraded to a placeholder', async () => {
     await cmdToday('2026-06-30', ctx([placeholder()]));
     const o = text();
-    expect(o).toContain('Group A Winner'); // the placeholder fixture itself still renders
+    expect(o).toContain('Group A 2nd Place'); // the placeholder fixture itself still renders
     expect(o).not.toContain('45%'); // its inherited market percentages do NOT leak
     expect(o).not.toContain('32%');
   });
@@ -126,5 +129,10 @@ describe('CLI market gate — cached signal must not render against a degraded p
   it('markets <date>: drops the mismatched signal from the listing', async () => {
     await cmdMarkets('2026-06-30', undefined, ctx([placeholder()]));
     expect(text()).not.toContain('45%');
+  });
+
+  it('markets <date>: lists it when the fixture is resolved (positive control)', async () => {
+    await cmdMarkets('2026-06-30', undefined, ctx([mexEcu()]));
+    expect(text()).toContain('45%');
   });
 });

--- a/packages/mcp/test/market-degraded.test.ts
+++ b/packages/mcp/test/market-degraded.test.ts
@@ -34,11 +34,14 @@ function mexEcu(over: Partial<Match> = {}): Match {
   };
 }
 
-/** The bundle placeholder the feed degrades back to — same id, unresolved teams. */
+/**
+ * The bundle placeholder the feed degrades back to — same id, unresolved teams.
+ * Mirrors the real bundled slot 760486 (`2A`/`2B`, "Group A/B 2nd Place", 🏳️).
+ */
 function placeholder(): Match {
   return mexEcu({
-    home: { code: '1A', name: 'Group A Winner', flag: '🏳️' },
-    away: { code: '2B', name: 'Group B Runner-up', flag: '🏳️' },
+    home: { code: '2A', name: 'Group A 2nd Place', flag: '🏳️' },
+    away: { code: '2B', name: 'Group B 2nd Place', flag: '🏳️' },
   });
 }
 

--- a/packages/mcp/test/market-degraded.test.ts
+++ b/packages/mcp/test/market-degraded.test.ts
@@ -1,0 +1,108 @@
+/**
+ * MARKET-GATE DEGRADED GUARD (MCP) — twin of
+ * packages/cli/test/market-degraded.test.ts (see that header). review-discipline
+ * rule 11: a market signal cached by match id must NOT surface against a degraded
+ * 🏳️ placeholder that inherited its id when the live feed falls back to the bundle.
+ * Drives the real MCP tools with the adverse cache state reconstructed.
+ */
+import {
+  buildMarketSignal,
+  FakeMarketProvider,
+  type Match,
+  type MarketSignal,
+  normalizeOutcomes,
+  type ProviderAdapter,
+} from '@claudinho/core';
+import { describe, expect, it } from 'vitest';
+import { toolGetMarketSignal, toolGetToday } from '../src/tools';
+
+const KO_ID = '760486'; // the canonical fake R32 tie used across coverage tests
+const KICK = '2026-06-30T18:00Z';
+const RENDER_NOW = new Date('2026-06-30T12:00:00Z'); // pre-kickoff → market-relevant
+
+function mexEcu(over: Partial<Match> = {}): Match {
+  return {
+    id: KO_ID,
+    stage: 'R32',
+    kickoff: KICK,
+    venue: 'SoFi Stadium',
+    home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+    away: { code: 'ECU', name: 'Ecuador', flag: '🇪🇨' },
+    status: 'SCHEDULED',
+    updatedAt: '2026-06-30T00:00Z',
+    ...over,
+  };
+}
+
+/** The bundle placeholder the feed degrades back to — same id, unresolved teams. */
+function placeholder(): Match {
+  return mexEcu({
+    home: { code: '1A', name: 'Group A Winner', flag: '🏳️' },
+    away: { code: '2B', name: 'Group B Runner-up', flag: '🏳️' },
+  });
+}
+
+/** A signal cached while the fixture WAS resolved: matchId KO_ID, MEX/ECU outcomes. */
+function cachedSignal(): MarketSignal {
+  return buildMarketSignal({
+    match: mexEcu(),
+    source: 'fake',
+    asOf: '2026-06-30T11:55Z',
+    outcomes: normalizeOutcomes([
+      { kind: 'home', teamCode: 'MEX', label: 'Mexico', probability: 0.45 },
+      { kind: 'draw', label: 'Draw', probability: 0.32 },
+      { kind: 'away', teamCode: 'ECU', label: 'Ecuador', probability: 0.23 },
+    ]),
+    liquidity: 500_000,
+    now: new Date('2026-06-30T11:55Z'),
+  });
+}
+
+const provider = () => new FakeMarketProvider({ signals: { [KO_ID]: cachedSignal() } });
+
+function adapterFor(window: Match[]): ProviderAdapter {
+  return {
+    name: 'espn',
+    capabilities: { push: false, latencyHintSec: 0 },
+    async fetchByDate() {
+      return window;
+    },
+    async fetchLive() {
+      return [];
+    },
+    async fetchWindow() {
+      return window;
+    },
+  };
+}
+const args = (window: Match[]) => ({
+  date: '2026-06-30',
+  tz: 'UTC',
+  adapter: adapterFor(window),
+  marketProvider: provider(),
+  now: RENDER_NOW,
+});
+
+describe('MCP market gate — cached signal must not surface against a degraded placeholder (rule 11)', () => {
+  it('get_today: DROPS the inherited market when the fixture degraded to a placeholder', async () => {
+    const r = await toolGetToday(args([placeholder()]));
+    const data = r.data as { marketSignals?: Record<string, unknown> };
+    expect(data.marketSignals?.[KO_ID]).toBeUndefined();
+  });
+
+  it('get_today: KEEPS the market when the fixture is resolved (positive control)', async () => {
+    const r = await toolGetToday(args([mexEcu()]));
+    const data = r.data as { marketSignals?: Record<string, unknown> };
+    expect(data.marketSignals?.[KO_ID]).toBeDefined();
+  });
+
+  it('get_market_signal { date }: drops the mismatched signal from the listing', async () => {
+    const r = await toolGetMarketSignal(args([placeholder()]));
+    expect((r.data as { signals: unknown[] }).signals).toHaveLength(0);
+  });
+
+  it('get_market_signal { date }: lists it when resolved (positive control)', async () => {
+    const r = await toolGetMarketSignal(args([mexEcu()]));
+    expect((r.data as { signals: unknown[] }).signals).toHaveLength(1);
+  });
+});

--- a/scripts/release-qa.sh
+++ b/scripts/release-qa.sh
@@ -166,8 +166,8 @@ const sig = buildMarketSignal({ match: resolved, source:'fake', asOf:'2026-06-30
   outcomes: normalizeOutcomes([{kind:'home',teamCode:'MEX',label:'Mexico',probability:0.45},
     {kind:'draw',label:'Draw',probability:0.32},{kind:'away',teamCode:'ECU',label:'Ecuador',probability:0.23}]),
   now: new Date('2026-06-30T11:55Z') });
-const placeholder = { ...resolved, home:{code:'1A',name:'Group A Winner',flag:'🏳️'},
-  away:{code:'2B',name:'Group B Runner-up',flag:'🏳️'} };
+const placeholder = { ...resolved, home:{code:'2A',name:'Group A 2nd Place',flag:'🏳️'},
+  away:{code:'2B',name:'Group B 2nd Place',flag:'🏳️'} };
 const ok = marketSignalRendersFor(resolved, sig) === true && marketSignalRendersFor(placeholder, sig) === false;
 process.stdout.write(ok ? 'GATE-OK' : 'GATE-LEAK');
 " 2>/dev/null)"

--- a/scripts/release-qa.sh
+++ b/scripts/release-qa.sh
@@ -146,6 +146,39 @@ else
   SKIP=$((SKIP+1))
 fi
 
+# T6 — DETERMINISTIC, feed-independent: the market gate must NOT render a cached
+# signal against a degraded knockout placeholder. Market signals are cached by
+# match id but display labels come from the CURRENT fixture, so when the feed
+# degrades and a KO slot falls back to the bundle's 🏳️ placeholder (same id), a
+# cached MEX/ECU signal could print "Group A Winner 43% · …". `marketSignalRendersFor`
+# (matchId + mapsCleanly) is the chokepoint; assert it suppresses the mismatch
+# and still passes the resolved fixture (positive control). (v0.8.12 review P1.)
+if [ -n "${CLI:-}" ]; then
+  printf '  \033[33m⚠ SKIP\033[0m  market-gate degraded check (CLI override tests a global install; tripwire imports the local core)\n'
+  SKIP=$((SKIP+1))
+elif [ -f "$CORE_DIST" ]; then
+  GATE="$(node --input-type=module -e "
+import { marketSignalRendersFor, buildMarketSignal, normalizeOutcomes } from 'file://$CORE_DIST';
+const resolved = { id:'g', stage:'R32', kickoff:'2026-06-30T18:00Z', venue:'X',
+  home:{code:'MEX',name:'Mexico',flag:'🇲🇽'}, away:{code:'ECU',name:'Ecuador',flag:'🇪🇨'},
+  status:'SCHEDULED', updatedAt:'2026-06-30T00:00Z' };
+const sig = buildMarketSignal({ match: resolved, source:'fake', asOf:'2026-06-30T11:55Z',
+  outcomes: normalizeOutcomes([{kind:'home',teamCode:'MEX',label:'Mexico',probability:0.45},
+    {kind:'draw',label:'Draw',probability:0.32},{kind:'away',teamCode:'ECU',label:'Ecuador',probability:0.23}]),
+  now: new Date('2026-06-30T11:55Z') });
+const placeholder = { ...resolved, home:{code:'1A',name:'Group A Winner',flag:'🏳️'},
+  away:{code:'2B',name:'Group B Runner-up',flag:'🏳️'} };
+const ok = marketSignalRendersFor(resolved, sig) === true && marketSignalRendersFor(placeholder, sig) === false;
+process.stdout.write(ok ? 'GATE-OK' : 'GATE-LEAK');
+" 2>/dev/null)"
+  [ "$GATE" = "GATE-OK" ] \
+    && check ok  "market gate suppresses a cached signal on a degraded placeholder (deterministic)" \
+    || check no  "market gate suppresses a cached signal on a degraded placeholder (deterministic)"
+else
+  printf '  \033[33m⚠ SKIP\033[0m  market-gate degraded check (core dist not built — run pnpm -r build)\n'
+  SKIP=$((SKIP+1))
+fi
+
 echo
 bold "tripwires: $PASS passed · $FAIL failed · $SKIP skipped"
 echo "NOTE: this covers CLI/share rendering. MCP arg-threading (tz/lang on get_bracket"


### PR DESCRIPTION
Executable guards for the 0.8.12 review **P1** — the fix shipped, this is the regression net (review-discipline **rule 11**). Test/docs only, **no version bump** (cf. #47).

## The bug class
A market signal is cached by match id, but display labels come from the *current* `Match`. When the live feed degrades and a knockout slot falls back to the bundle's 🏳️ placeholder (**same id**, unresolved teams), a cached MEX/ECU signal could print as `Group A Winner 43% · …` — a confidently-wrong market on a placeholder. The shipped fix routes every render through core `marketSignalRendersFor(match, signal)`; the unit test covers the predicate, but nothing reconstructed the **adverse cache state end-to-end** — the gap a happy-path check and a clean `release:qa` run both miss (the bug needs a populated cache **and** a degraded feed at render time).

## What this adds
- **CLI** `market-degraded.test.ts` — drives `today` + `markets <date>` with a resolved-then-cached signal + a degraded fixture sharing its id → market **suppressed**, with a resolved-fixture **positive control** (45% shows) so the suppression assertion isn't vacuous.
- **MCP** `market-degraded.test.ts` — same for `get_today` + `get_market_signal{date}`.
- **release:qa T6** — deterministic, feed-independent tripwire asserting `marketSignalRendersFor` suppresses the mismatch and passes the resolved fixture (proven even when the live feed degrades to SKIP).

Pairs with the resolved-path `knockout-surface-coverage.test.ts` — this is its degraded twin.

core 211 / cli 208 / mcp 75; lint + release:qa (**6 tripwires**) green. Not MCP-affecting → no Registry republish.

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>