### PR TITLE
chore: add smithery.yaml for the Smithery MCP listing

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,29 @@
+# Smithery listing for the Claudinho MCP server (https://smithery.ai).
+# Claudinho is a zero-config STDIO server — run via `npx -y @claudinho/mcp`,
+# no API key. Listed as a local server (Smithery hands users this launch config;
+# it isn't hosted). Only env the server honors is surfaced below.
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      markets:
+        type: boolean
+        default: true
+        description: >-
+          Show read-only Polymarket signals on get_today / get_match
+          (informational only, never betting advice). Set false to disable.
+      flavor:
+        type: string
+        enum: ["off", "subtle", "full"]
+        default: "full"
+        description: Localized commentary flair on match lines (off | subtle | full).
+  commandFunction: |-
+    (config) => ({
+      command: 'npx',
+      args: ['-y', '@claudinho/mcp'],
+      env: {
+        ...(config.markets === false ? { CLAUDINHO_MARKETS: 'off' } : {}),
+        ...(config.flavor ? { CLAUDINHO_FLAVOR: config.flavor } : {}),
+      },
+    })


### PR DESCRIPTION
Adds a `smithery.yaml` so Claudinho can be listed on [Smithery](https://smithery.ai) via the **Connect-GitHub-repo** flow.

**Why:** Smithery's `/servers/new` form is for remote/hosted servers (it wants an HTTP URL). Claudinho is a **stdio** server (`npx -y @claudinho/mcp`), so it has no URL — the stdio path is a `smithery.yaml` declaring a `type: stdio` start command, scanned from the repo.

- Zero required config (no API key); surfaces only the two env knobs the MCP server actually honors — `CLAUDINHO_MARKETS` and `CLAUDINHO_FLAVOR` (verified in `packages/mcp/src`). tz/lang are per-call args, not env, so they're intentionally omitted.
- Lists as a **local** server (Smithery hands users the launch config; it doesn't host it) — correct for an offline-first npx tool.
- **Config/docs only** — Smithery reads it from GitHub, so **no version bump, no npm publish, not MCP-affecting**. YAML validated; lint green.

**After merge:** connect the repo at smithery.ai (Deploy from GitHub), not the URL form.

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>