### PR TITLE
feat(cli): "¿Y si sí?" rally cry on today/next when Mexico plays

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -221,6 +221,19 @@ function resolveTeamArg(team: string | undefined, usage: string): string {
 }
 
 /** `claudinho today [date]` */
+/**
+ * Viral 2026 Mexico rally cry ("¿Y si sí?"). Shown in ALL locales on `today` and
+ * `next` whenever MEX is in the match — a fan flourish, not translated. Text-only
+ * flair: suppressed by `--flavor off` and never in `--json` (both commands return
+ * early on json). Returns the styled phrase or undefined; the caller adds indent.
+ */
+const MEX_RALLY = '¿Y si sí?';
+function mexRally(m: Match, cfg: CliConfig, c: ReturnType<typeof painterFor>): string | undefined {
+  if (cfg.flavor === 'off') return undefined;
+  if (m.home.code !== 'MEX' && m.away.code !== 'MEX') return undefined;
+  return c.green(MEX_RALLY);
+}
+
 export async function cmdToday(date: string | undefined, ctx: Ctx): Promise<void> {
   const { cfg, t } = ctx;
   precheck(cfg, t, date);
@@ -255,6 +268,8 @@ export async function cmdToday(date: string | undefined, ctx: Ctx): Promise<void
       out(matchLine(m, cfg, t, c, flags));
       const s = signals.get(m.id);
       if (s) out('    ' + c.dim(marketLine(s, m)));
+      const rally = mexRally(m, cfg, c);
+      if (rally) out('    ' + rally);
     }
   }
   out();
@@ -340,6 +355,8 @@ export async function cmdNext(team: string | undefined, ctx: Ctx): Promise<void>
           t('next.in', { countdown: countdown(fixture.kickoff) }),
       ),
   );
+  const rally = mexRally(fixture, cfg, c);
+  if (rally) out('  ' + rally);
   out();
   // Attribute the provider when the live overlay resolved the fixture (a
   // knockout tie); a static group fixture carries no source.

--- a/packages/cli/test/mex-rally.test.ts
+++ b/packages/cli/test/mex-rally.test.ts
@@ -1,0 +1,103 @@
+import type { Match, ProviderAdapter } from '@claudinho/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cmdNext, cmdToday } from '../src/commands';
+import type { CliConfig } from '../src/config';
+import { makeT } from '../src/i18n';
+
+const RALLY = '¿Y si sí?';
+const NOW = new Date('2026-06-30T12:00:00Z');
+
+function m(over: Partial<Match> = {}): Match {
+  return {
+    id: '760486',
+    stage: 'R32',
+    kickoff: '2026-07-01T01:00Z',
+    venue: 'SoFi Stadium',
+    home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+    away: { code: 'ECU', name: 'Ecuador', flag: '🇪🇨' },
+    status: 'SCHEDULED',
+    updatedAt: '2026-06-30T00:00Z',
+    ...over,
+  };
+}
+const notMex = m({
+  id: '760488',
+  home: { code: 'BRA', name: 'Brazil', flag: '🇧🇷' },
+  away: { code: 'JPN', name: 'Japan', flag: '🇯🇵' },
+});
+
+function adapter(window: Match[]): ProviderAdapter {
+  return {
+    name: 'espn',
+    capabilities: { push: false, latencyHintSec: 0 },
+    async fetchByDate() {
+      return window;
+    },
+    async fetchLive() {
+      return [];
+    },
+    async fetchWindow() {
+      return window;
+    },
+  };
+}
+
+function cfg(over: Partial<CliConfig> = {}): CliConfig {
+  return { lang: 'en', tz: 'UTC', json: false, color: false, source: 'espn', flavor: 'full', ...over };
+}
+const ctx = (window: Match[], over: Partial<CliConfig> = {}) => ({
+  cfg: cfg(over),
+  t: makeT(over.lang ?? 'en'),
+  adapter: adapter(window),
+  marketProvider: undefined,
+  now: NOW,
+});
+
+const outSpy = vi.spyOn(process.stdout, 'write');
+let writes: string[] = [];
+beforeEach(() => {
+  writes = [];
+  outSpy.mockImplementation((c: unknown) => {
+    writes.push(String(c));
+    return true;
+  });
+});
+afterEach(() => outSpy.mockReset());
+const text = () => writes.join('');
+
+describe('¿Y si sí? — Mexico rally cry on today/next', () => {
+  it('today: shows it for a MEX match (even in English)', async () => {
+    await cmdToday('2026-07-01', ctx([m()], { lang: 'en' }));
+    expect(text()).toContain(RALLY);
+  });
+
+  it('today: shows it exactly once, only for the MEX match', async () => {
+    await cmdToday('2026-07-01', ctx([m(), notMex]));
+    expect(text().split(RALLY).length - 1).toBe(1);
+  });
+
+  it('today: NOT shown when no MEX match is on the card', async () => {
+    await cmdToday('2026-07-01', ctx([notMex]));
+    expect(text()).not.toContain(RALLY);
+  });
+
+  it('today: suppressed by --flavor off', async () => {
+    await cmdToday('2026-07-01', ctx([m()], { flavor: 'off' }));
+    expect(text()).not.toContain(RALLY);
+  });
+
+  it('today: never in --json', async () => {
+    await cmdToday('2026-07-01', ctx([m()], { json: true }));
+    expect(text()).not.toContain('si sí');
+  });
+
+  it('next MEX: shows it', async () => {
+    await cmdNext('MEX', ctx([m()]));
+    expect(text()).toContain(RALLY);
+  });
+
+  it('next: not shown for a team whose fixture has no MEX', async () => {
+    await cmdNext('BRA', ctx([notMex]));
+    expect(text()).not.toContain(RALLY);
+  });
+});


### PR DESCRIPTION
Ships the viral 2026 Mexico rally cry **"¿Y si sí?"** on `today` and `next` whenever **MEX is in the match** (home or away).

- **All locales** (including English) — it's a fan flourish, shown verbatim, not translated.
- **Text-only flair:** suppressed by `--flavor off`, and never in `--json` (both commands return early on json). Green accent line under the match.
- Scope: `today` + `next` (as requested). Easy to extend to `match`/`share` later if you want.

Verified end-to-end: shows for MEX–ECU on `today` (even in English) and `next MEX`; absent on non-MEX matches; gone with `--flavor off`; not in `--json`. Test: `mex-rally.test.ts` (7 cases). `core 211 / cli 221 / mcp 75`, lint + release:qa green. CLI-only → not MCP-affecting.

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>