### PR TITLE
fix(cli): "¿Y si sí?" inline in the flair slot (not a separate line)

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -221,19 +221,6 @@ function resolveTeamArg(team: string | undefined, usage: string): string {
 }
 
 /** `claudinho today [date]` */
-/**
- * Viral 2026 Mexico rally cry ("¿Y si sí?"). Shown in ALL locales on `today` and
- * `next` whenever MEX is in the match — a fan flourish, not translated. Text-only
- * flair: suppressed by `--flavor off` and never in `--json` (both commands return
- * early on json). Returns the styled phrase or undefined; the caller adds indent.
- */
-const MEX_RALLY = '¿Y si sí?';
-function mexRally(m: Match, cfg: CliConfig, c: ReturnType<typeof painterFor>): string | undefined {
-  if (cfg.flavor === 'off') return undefined;
-  if (m.home.code !== 'MEX' && m.away.code !== 'MEX') return undefined;
-  return c.green(MEX_RALLY);
-}
-
 export async function cmdToday(date: string | undefined, ctx: Ctx): Promise<void> {
   const { cfg, t } = ctx;
   precheck(cfg, t, date);
@@ -268,8 +255,6 @@ export async function cmdToday(date: string | undefined, ctx: Ctx): Promise<void
       out(matchLine(m, cfg, t, c, flags));
       const s = signals.get(m.id);
       if (s) out('    ' + c.dim(marketLine(s, m)));
-      const rally = mexRally(m, cfg, c);
-      if (rally) out('    ' + rally);
     }
   }
   out();
@@ -355,8 +340,6 @@ export async function cmdNext(team: string | undefined, ctx: Ctx): Promise<void>
           t('next.in', { countdown: countdown(fixture.kickoff) }),
       ),
   );
-  const rally = mexRally(fixture, cfg, c);
-  if (rally) out('  ' + rally);
   out();
   // Attribute the provider when the live overlay resolved the fixture (a
   // knockout tie); a static group fixture carries no source.

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -93,8 +93,12 @@ export function matchLine(
   } else {
     right = statusToken(m, t, c);
   }
-  const flair = matchFlavor(m, { level: cfg.flavor, locale: cfg.lang });
-  const tail = flair ? `   ${c.dim(flair)}` : '';
+  // Mexico's viral 2026 rally cry ("¿Y si sí?") takes the flair slot whenever MEX
+  // is playing — all locales, a fan flourish, not translated. Still silenced by
+  // --flavor off. Green so it pops past the usual dimmed commentary.
+  const mexRally = (m.home.code === 'MEX' || m.away.code === 'MEX') && cfg.flavor !== 'off';
+  const flair = mexRally ? '¿Y si sí?' : matchFlavor(m, { level: cfg.flavor, locale: cfg.lang });
+  const tail = flair ? `   ${mexRally ? c.green(flair) : c.dim(flair)}` : '';
   return `  ${left}   ${right}${tail}`.trimEnd();
 }
 

--- a/packages/cli/test/format.test.ts
+++ b/packages/cli/test/format.test.ts
@@ -26,24 +26,29 @@ function liveMatch(over: Partial<Match> = {}): Match {
   };
 }
 
-const render = (c: CliConfig) => matchLine(liveMatch(), c, makeT(c.lang), painterFor(c));
+// Generic-flair wiring is tested on a NON-MEX match: MEX intentionally overrides
+// the genre flair with its "¿Y si sí?" rally cry (see matchLine), so it can't be
+// used to verify that the ordinary localized commentary flows through.
+const liveNonMex = (over: Partial<Match> = {}): Match =>
+  liveMatch({ home: { code: 'BRA', name: 'Brazil', flag: '🇧🇷' }, ...over });
+const render = (c: CliConfig) => matchLine(liveNonMex(), c, makeT(c.lang), painterFor(c));
 
 describe('matchLine — flavor wiring', () => {
   it('appends the localized flair at flavor=full', () => {
     const c = cfg({ flavor: 'full' });
-    const flair = matchFlavor(liveMatch(), { level: 'full', locale: 'en' });
+    const flair = matchFlavor(liveNonMex(), { level: 'full', locale: 'en' });
     expect(flair).not.toBe('');
     expect(render(c)).toContain(flair);
   });
 
   it('omits flair at flavor=off', () => {
-    const flair = matchFlavor(liveMatch(), { level: 'full', locale: 'en' });
+    const flair = matchFlavor(liveNonMex(), { level: 'full', locale: 'en' });
     expect(render(cfg({ flavor: 'off' }))).not.toContain(flair);
   });
 
   it('localizes the flair to the configured language', () => {
     const es = render(cfg({ flavor: 'full', lang: 'es' }));
-    expect(es).toContain(matchFlavor(liveMatch(), { level: 'full', locale: 'es' }));
+    expect(es).toContain(matchFlavor(liveNonMex(), { level: 'full', locale: 'es' }));
   });
 
   it('drops flag emoji when flags are off (names only)', () => {

--- a/packages/cli/test/mex-rally.test.ts
+++ b/packages/cli/test/mex-rally.test.ts
@@ -66,9 +66,11 @@ afterEach(() => outSpy.mockReset());
 const text = () => writes.join('');
 
 describe('¿Y si sí? — Mexico rally cry on today/next', () => {
-  it('today: shows it for a MEX match (even in English)', async () => {
+  it('today: shows it INLINE on the MEX match line, not a separate line (even in English)', async () => {
     await cmdToday('2026-07-01', ctx([m()], { lang: 'en' }));
-    expect(text()).toContain(RALLY);
+    // It takes the flair slot: same line as the match, after the kickoff/status.
+    const mexLine = text().split('\n').find((l) => l.includes('Mexico'));
+    expect(mexLine).toContain(RALLY);
   });
 
   it('today: shows it exactly once, only for the MEX match', async () => {


### PR DESCRIPTION
0.8.14 printed the rally cry on its **own line** under the match. It should be the **flair** — inline at the end of the MEX match line, replacing the genre commentary. This fixes the placement.

- Moved into `matchLine` (single chokepoint → `today`/`live`/`next`/`match` all inherit it), green so it pops past the dimmed commentary.
- Still silenced by `--flavor off`, never in `--json`.
- Reverted the separate-line helper + call sites in `commands.ts`.
- `format.test.ts` flair-wiring tests now use a non-MEX match (MEX intentionally overrides the genre flair); `mex-rally.test.ts` asserts the phrase is **on the same line as the match** so the separate-line regression can't return.

`🇲🇽 Mexico  vs  Ecuador 🇪🇨   mar, 19:00   ¿Y si sí?`

core 211 / cli 221 / mcp 75; lint + release:qa green. CLI-only, not MCP-affecting.

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>