### PR TITLE
docs: add the Glama A-rating badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![npm: @claudinho/mcp](https://img.shields.io/npm/v/@claudinho/mcp?label=%40claudinho%2Fmcp&color=cb3837)](https://www.npmjs.com/package/@claudinho/mcp)
 [![npm downloads](https://img.shields.io/npm/dm/@claudinho/cli?label=downloads&color=cb3837)](https://www.npmjs.com/package/@claudinho/cli)
 [![cursor.directory](https://img.shields.io/badge/cursor.directory-claudinho-0b0b0b)](https://cursor.directory/plugins/claudinho)
+[![Glama](https://glama.ai/mcp/servers/arturogarrido/claudinho/badge)](https://glama.ai/mcp/servers/arturogarrido/claudinho)
 [![node](https://img.shields.io/node/v/@claudinho/cli?color=5fa04e)](https://nodejs.org)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![#VibingLaVidaLoca](https://img.shields.io/badge/%23VibingLaVidaLoca-⚽-ff5a5f)](https://github.com/arturogarrido/claudinho)


### PR DESCRIPTION
Adds the [Glama](https://glama.ai/mcp/servers/arturogarrido/claudinho) quality badge to the README badge row. Claudinho's Glama page rates it **A** on License / Quality / Maintenance — real third-party social proof, and it's the badge that gated the (now-merged) awesome-mcp-servers listing.

Docs-only, no version bump. Sits next to the cursor.directory badge.

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>