### PR TITLE
docs: add the Smithery badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![npm: @claudinho/mcp](https://img.shields.io/npm/v/@claudinho/mcp?label=%40claudinho%2Fmcp&color=cb3837)](https://www.npmjs.com/package/@claudinho/mcp)
 [![npm downloads](https://img.shields.io/npm/dm/@claudinho/cli?label=downloads&color=cb3837)](https://www.npmjs.com/package/@claudinho/cli)
 [![cursor.directory](https://img.shields.io/badge/cursor.directory-claudinho-0b0b0b)](https://cursor.directory/plugins/claudinho)
+[![smithery badge](https://smithery.ai/badge/arturogarrido/claudinho)](https://smithery.ai/servers/arturogarrido/claudinho)
 [![node](https://img.shields.io/node/v/@claudinho/cli?color=5fa04e)](https://nodejs.org)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![#VibingLaVidaLoca](https://img.shields.io/badge/%23VibingLaVidaLoca-⚽-ff5a5f)](https://github.com/arturogarrido/claudinho)


### PR DESCRIPTION
Claudinho is now live on [Smithery](https://smithery.ai/servers/arturogarrido/claudinho) — adds the Smithery badge next to the cursor.directory one. Docs-only, no version bump.

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>