### PR TITLE
docs: add the Glama A-rating badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/@claudinho/cli?label=downloads&color=cb3837)](https://www.npmjs.com/package/@claudinho/cli)
 [![cursor.directory](https://img.shields.io/badge/cursor.directory-claudinho-0b0b0b)](https://cursor.directory/plugins/claudinho)
 [![smithery badge](https://smithery.ai/badge/arturogarrido/claudinho)](https://smithery.ai/servers/arturogarrido/claudinho)
+[![Glama](https://glama.ai/mcp/servers/arturogarrido/claudinho/badge)](https://glama.ai/mcp/servers/arturogarrido/claudinho)
 [![node](https://img.shields.io/node/v/@claudinho/cli?color=5fa04e)](https://nodejs.org)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![#VibingLaVidaLoca](https://img.shields.io/badge/%23VibingLaVidaLoca-⚽-ff5a5f)](https://github.com/arturogarrido/claudinho)


### PR DESCRIPTION
Adds the [Glama](https://glama.ai/mcp/servers/arturogarrido/claudinho) quality badge (**A** on License / Quality / Maintenance) next to the cursor.directory + Smithery badges. Docs-only, no version bump. Supersedes #63 (which was stale after the Smithery badge landed in the same spot).

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>