### PR TITLE
docs: fix broken README badges (Glama card + stars)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![npm downloads](https://img.shields.io/npm/dm/@claudinho/cli?label=downloads&color=cb3837)](https://www.npmjs.com/package/@claudinho/cli)
 [![cursor.directory](https://img.shields.io/badge/cursor.directory-claudinho-0b0b0b)](https://cursor.directory/plugins/claudinho)
 [![smithery badge](https://smithery.ai/badge/arturogarrido/claudinho)](https://smithery.ai/servers/arturogarrido/claudinho)
-[![Glama](https://glama.ai/mcp/servers/arturogarrido/claudinho/badge)](https://glama.ai/mcp/servers/arturogarrido/claudinho)
+[![Glama: A](https://img.shields.io/badge/Glama-A-2ea043)](https://glama.ai/mcp/servers/arturogarrido/claudinho)
 [![node](https://img.shields.io/node/v/@claudinho/cli?color=5fa04e)](https://nodejs.org)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![#VibingLaVidaLoca](https://img.shields.io/badge/%23VibingLaVidaLoca-⚽-ff5a5f)](https://github.com/arturogarrido/claudinho)
-[![GitHub stars](https://img.shields.io/github/stars/arturogarrido/claudinho?style=social)](https://github.com/arturogarrido/claudinho)
+[![GitHub stars](https://img.shields.io/github/stars/arturogarrido/claudinho?style=flat&logo=github&label=stars&color=f5c518)](https://github.com/arturogarrido/claudinho)
 
 **Live scores for the 2026 men's football tournament — in your terminal, your Claude Code / Cursor CLI statusline, and any MCP client.** No API key, no signup; all 104 fixtures ship bundled, so the schedule works offline.
 


### PR DESCRIPTION
Fixes the two badges called out as broken:

- **Glama** — `glama.ai/.../badge` returns a big **PNG card**, not a small badge, so it rendered as a huge image in the badge row. Replaced with a small `Glama | A` shields badge that links to the live Glama page. (Static snapshot of the A rating; the live page is authoritative.)
- **GitHub stars** — the `style=social` badge rendered "Stars invalid" (a stale GitHub camo cache of a transient shields error; the URL actually returns 18). Switched to a **flat** github-logo stars badge — matches the rest of the row, and the new URL busts the cache.

Docs-only, no version bump.

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>