### PR TITLE
build(mcp): carry tool annotations + titles into the .mcpb manifest (Smithery score)

### DIFF
--- a/packages/mcp/scripts/build-mcpb.mjs
+++ b/packages/mcp/scripts/build-mcpb.mjs
@@ -97,8 +97,13 @@ try {
   const declaredByName = Object.fromEntries((manifest.tools ?? []).map((t) => [t.name, t]));
   manifest.tools = serverTools.map((t) => ({
     name: t.name,
+    ...(t.title ? { title: t.title } : {}),
     description: declaredByName[t.name]?.description ?? t.description,
     inputSchema: t.inputSchema,
+    // Carry the server's real annotations (readOnlyHint/openWorldHint) into the
+    // manifest — Smithery scores the bundled manifest, so without these it reports
+    // "Annotations 0/8" even though every tool declares them.
+    ...(t.annotations ? { annotations: t.annotations } : {}),
   }));
   writeFileSync(join(stage, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
 


### PR DESCRIPTION
Smithery scores the bundled **manifest**, so it reported **Annotations 0/8** even though every Claudinho tool declares `readOnlyHint`/`openWorldHint` on the server — `build:mcpb` just wasn't copying them into the manifest.

Now it carries each tool's `annotations` (and `title`) from the `tools/list` it already runs into the manifest, next to the `inputSchema`. Fixes the Smithery annotation score (**+~5.93 pts → ~88** once re-published, on top of the +12 Homepage). No server/npm change, not MCP-affecting.

Verified: all 8 manifest tools now carry `annotations` + `title` + `inputSchema`.

**After merge:** re-run `pnpm -F @claudinho/mcp build:mcpb` (already done) → `smithery mcp publish packages/mcp/dist/claudinho-0.8.15.mcpb -n arturogarrido/claudinho`.

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>