### PR TITLE
feat(mcp): declare outputSchema + structuredContent on all 8 tools (0.8.16)

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claudinho",
   "description": "Live 2026 World Cup scores, fixtures, and group standings for your Cursor agent — a read-only MCP server. No API keys. Pairs with the Claudinho Cursor CLI statusline. Independent fan project, not affiliated with FIFA or Anthropic.",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "author": { "name": "Arturo Garrido" },
   "homepage": "https://github.com/arturogarrido/claudinho#readme",
   "repository": "https://github.com/arturogarrido/claudinho",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,14 @@ To cut a release:
 **MCP-affecting releases** (anything that changes a tool's shape or description) also bump
 `packages/mcp/server.json` and re-publish to the MCP Registry (`mcp-publisher publish`).
 
+**Adding or changing an MCP tool:** every tool declares an `outputSchema` and returns
+`structuredContent` (`packages/mcp/src/server.ts`). A **new** tool must be added to
+`OUTPUT_SCHEMAS` *and* to `packages/mcp/test/output-schema.test.ts` (which parses each handler's
+`data` — healthy **and** degraded — against its schema). The output schemas are **hand-mirrored**
+from the `@claudinho/core` types and kept permissive (`.passthrough()` on nested objects); the
+`.strict()` top-level guard test is the safety net that catches schema/handler drift, so keep it
+green. `build:mcpb` injects these schemas into the Smithery-scored `.mcpb` manifest.
+
 **Smithery (`.mcpb`) re-publish** — optional, and only when you want the Smithery listing to
 track a new version: `pnpm -F @claudinho/mcp build:mcpb` (stages `mcpb/manifest.json` + the tsup
 server + its external deps, smoke-tests it, then `mcpb pack` → `packages/mcp/dist/claudinho-<v>.mcpb`),

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudinho/cli",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Live scores, fixtures, group tables, and read-only prediction-market signals for the 2026 men's football tournament — in your terminal, Claude Code, and Cursor CLI statusline. No API keys. Not affiliated with FIFA or Anthropic.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudinho/core",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Domain model, provider adapters (ESPN), standings, bundled schedule, and the read-only Polymarket market-signal sidecar powering Claudinho. Not affiliated with FIFA or Anthropic.",
   "type": "module",
   "license": "MIT",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -54,7 +54,8 @@ Then just ask your agent naturally — it picks the right tool and answers with 
 
 All tools are **read-only** (`readOnlyHint`) and accept optional `tz`, `lang`
 (`en`/`es`/`pt`/`fr`), and `flavor` (`off`/`subtle`/`full`). Every response carries
-human-readable text **and** structured JSON.
+human-readable text **and** structured content, validated against each tool's
+declared `outputSchema`.
 
 Resources: `standings://{group}`, `fixtures://{date}`. Prompts: `tournament_today`,
 and `my_team` (give it a 3-letter team code; combines next fixture, standings, and

--- a/packages/mcp/mcpb/manifest.json
+++ b/packages/mcp/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "claudinho",
   "display_name": "Claudinho ⚽",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Live scores, fixtures, and group standings for the 2026 men's football tournament. Not affiliated with FIFA or Anthropic.",
   "long_description": "Ask Claude about the 2026 men's football tournament — live scores, today's fixtures, a team's next match, group standings, and read-only prediction-market signals (informational only, not betting advice). Facts and emoji flags only; no logos, crests, or footage. An independent, open-source fan project. Not affiliated with or endorsed by FIFA or Anthropic.",
   "author": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudinho/mcp",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "mcpName": "io.github.arturogarrido/claudinho",
   "description": "MCP server for the 2026 men's football tournament — live scores, fixtures, standings, read-only prediction-market signals, and paste-ready match cards. Works with Claude Code, Cursor, Codex, Windsurf, Zed. Not affiliated with FIFA or Anthropic.",
   "type": "module",

--- a/packages/mcp/scripts/build-mcpb.mjs
+++ b/packages/mcp/scripts/build-mcpb.mjs
@@ -100,6 +100,10 @@ try {
     ...(t.title ? { title: t.title } : {}),
     description: declaredByName[t.name]?.description ?? t.description,
     inputSchema: t.inputSchema,
+    // Carry the server's live outputSchema too — Smithery scores the bundled
+    // manifest, so a tool that declares one in-process still reports "Output
+    // schemas 0/8" unless the manifest itself carries it.
+    ...(t.outputSchema ? { outputSchema: t.outputSchema } : {}),
     // Carry the server's real annotations (readOnlyHint/openWorldHint) into the
     // manifest — Smithery scores the bundled manifest, so without these it reports
     // "Annotations 0/8" even though every tool declares them.

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -7,12 +7,12 @@
     "source": "github",
     "subfolder": "packages/mcp"
   },
-  "version": "0.8.15",
+  "version": "0.8.16",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@claudinho/mcp",
-      "version": "0.8.15",
+      "version": "0.8.16",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -64,13 +64,110 @@ const commonArgs = {
   flavor: flavorArg.optional().describe('Commentary flair: off, subtle, full (default: full)'),
 };
 
-/** Wrap a ToolResult into the MCP tool response shape. */
+// ---- Output schemas (structured tool output) --------------------------------
+// Declared per tool so clients know each tool's return shape (and the .mcpb
+// manifest carries it). Deliberately PERMISSIVE: `.passthrough()` on objects so
+// no field is stripped and forward-compatible additions never break validation;
+// every branch-specific key is optional. Domain types live in @claudinho/core as
+// TS interfaces, so these are hand-mirrored (kept loose on purpose).
+const teamRef = z.object({ code: z.string(), name: z.string(), flag: z.string() }).partial().passthrough();
+const scorePair = z.object({ home: z.number(), away: z.number() }).partial().passthrough();
+const matchOut = z
+  .object({
+    id: z.string(),
+    stage: z.string().optional(),
+    group: z.string().nullable().optional(),
+    kickoff: z.string().optional(),
+    venue: z.string().optional(),
+    home: teamRef.optional(),
+    away: teamRef.optional(),
+    score: scorePair.nullable().optional(),
+    shootout: scorePair.optional(),
+    status: z.string().optional(),
+    minute: z.number().nullable().optional(),
+    winnerCode: z.string().optional(),
+  })
+  .passthrough();
+const anyObj = z.object({}).passthrough();
+const src = z.string().nullable();
+
+const todayOut = {
+  date: z.string(),
+  degraded: z.boolean(),
+  source: src,
+  count: z.number(),
+  matches: z.array(matchOut),
+  marketSignals: z.record(anyObj).optional(),
+};
+const liveOut = { degraded: z.boolean(), source: src, count: z.number(), matches: z.array(matchOut) };
+const matchDetailOut = {
+  match: matchOut.nullable(),
+  degraded: z.boolean().optional(),
+  source: src.optional(),
+  marketSignal: anyObj.nullable().optional(),
+};
+const standingsOut = {
+  degraded: z.boolean(),
+  source: src,
+  tables: z.union([anyObj, z.array(anyObj), z.null()]),
+};
+const bracketOut = {
+  view: anyObj.nullable(),
+  degraded: z.boolean().optional(),
+  standingsDegraded: z.boolean().optional(),
+  source: src.optional(),
+};
+const nextOut = { team: z.string(), fixture: matchOut.nullable(), degraded: z.boolean() };
+const marketOut = {
+  matchId: z.string().nullable().optional(),
+  team: z.string().optional(),
+  date: z.string().optional(),
+  degraded: z.boolean().optional(),
+  informationalOnly: z.boolean(),
+  signal: anyObj.nullable().optional(),
+  signals: z.array(anyObj).optional(),
+};
+const shareOut = {
+  kind: z.string(),
+  target: z.string().optional(),
+  snippet: z.string().optional(), // absent on the bracket "unknown stage" error branch
+  source: src.optional(),
+  informationalOnly: z.boolean().optional(),
+  degraded: z.boolean().optional(),
+  style: z.string().optional(),
+  team: z.string().optional(),
+  group: z.string().optional(),
+  stage: z.string().optional(),
+  tables: z.union([anyObj, z.array(anyObj), z.null()]).optional(),
+  view: anyObj.nullable().optional(),
+  matches: z.array(matchOut).optional(),
+  marketSignals: z.record(anyObj).optional(),
+};
+
+/**
+ * The per-tool output shapes, keyed by tool name (exported so a test can
+ * validate that every handler's `data` — healthy AND degraded — parses against
+ * the schema the tool advertises). Keep in lockstep with the registerTool calls.
+ */
+export const OUTPUT_SCHEMAS = {
+  get_today: todayOut,
+  get_live: liveOut,
+  get_match: matchDetailOut,
+  get_standings: standingsOut,
+  get_bracket: bracketOut,
+  get_next_fixture: nextOut,
+  get_market_signal: marketOut,
+  get_share_snippet: shareOut,
+} as const;
+
+/** Wrap a ToolResult into the MCP tool response shape (text + structured). */
 function toContent(r: ToolResult) {
   return {
     content: [
       { type: 'text' as const, text: r.text },
       { type: 'text' as const, text: '```json\n' + JSON.stringify(r.data, null, 2) + '\n```' },
     ],
+    structuredContent: r.data as Record<string, unknown>,
   };
 }
 
@@ -93,6 +190,7 @@ export function buildServer(): McpServer {
       },
       // Read-only; reaches an external data provider for the live overlay.
       annotations: { readOnlyHint: true, openWorldHint: true },
+      outputSchema: todayOut,
     },
     async (args) => toContent(await toolGetToday(args)),
   );
@@ -105,6 +203,7 @@ export function buildServer(): McpServer {
         'Only matches in play right now — each with current score and minute (empty when nothing is live). Use during matches for in-play state; for a full day\'s schedule including upcoming and finished, use get_today. tz/lang/flavor affect formatting only.',
       inputSchema: { ...commonArgs },
       annotations: { readOnlyHint: true, openWorldHint: true },
+      outputSchema: liveOut,
     },
     async (args) => toContent(await toolGetLive(args)),
   );
@@ -117,6 +216,7 @@ export function buildServer(): McpServer {
         "One match by its id, with live score/minute overlaid when it's in play. Get the id from get_today or get_live; to find a team's match without an id, use get_next_fixture. tz/lang/flavor affect formatting.",
       inputSchema: { id: z.string().describe('Match id'), ...commonArgs },
       annotations: { readOnlyHint: true, openWorldHint: true },
+      outputSchema: matchDetailOut,
     },
     async (args) => toContent(await toolGetMatch(args)),
   );
@@ -132,6 +232,7 @@ export function buildServer(): McpServer {
         ...commonArgs,
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
+      outputSchema: standingsOut,
     },
     async (args) => toContent(await toolGetStandings(args)),
   );
@@ -150,6 +251,7 @@ export function buildServer(): McpServer {
         ...commonArgs,
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
+      outputSchema: bracketOut,
     },
     async (args) => toContent(await toolGetBracket(args)),
   );
@@ -163,6 +265,7 @@ export function buildServer(): McpServer {
       inputSchema: { team: teamArg.describe('3-letter team code, e.g. MEX'), ...commonArgs },
       // Read-only; overlays live provider data for knockout pairings, so open-world.
       annotations: { readOnlyHint: true, openWorldHint: true },
+      outputSchema: nextOut,
     },
     async (args) => toContent(await toolGetNextFixture(args)),
   );
@@ -187,6 +290,7 @@ export function buildServer(): McpServer {
       },
       // Read-only; reaches an external prediction-market data provider.
       annotations: { readOnlyHint: true, openWorldHint: true },
+      outputSchema: marketOut,
     },
     async (args) => toContent(await toolGetMarketSignal(args)),
   );
@@ -224,6 +328,7 @@ export function buildServer(): McpServer {
       },
       // Read-only; may reach the live/market data providers (live/today/match).
       annotations: { readOnlyHint: true, openWorldHint: true },
+      outputSchema: shareOut,
     },
     async (args) => toContent(await toolGetShareSnippet(args)),
   );

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -160,7 +160,17 @@ export const OUTPUT_SCHEMAS = {
   get_share_snippet: shareOut,
 } as const;
 
-/** Wrap a ToolResult into the MCP tool response shape (text + structured). */
+/**
+ * Wrap a ToolResult into the MCP tool response shape.
+ *
+ * We emit the payload BOTH as `structuredContent` (schema-validated, for clients
+ * that support it) AND as a JSON block inside `content` — deliberately, not by
+ * oversight. MCP's backwards-compat guidance is that a tool with an outputSchema
+ * SHOULD still serialize the same data into a text block, so clients that don't
+ * read `structuredContent` (older/simple ones) still get the structured data.
+ * The redundancy costs a few tokens for agents that read both; dropping the text
+ * block would silently blind those older clients to everything but the prose.
+ */
 function toContent(r: ToolResult) {
   return {
     content: [

--- a/packages/mcp/test/output-schema.test.ts
+++ b/packages/mcp/test/output-schema.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Output-schema guard. Every MCP tool now advertises an `outputSchema` and
+ * returns `structuredContent`; the SDK validates that content against the schema
+ * on every call and rejects a mismatch (missing required key / wrong type). This
+ * asserts each handler's `data` parses against the schema its tool advertises —
+ * across BOTH the healthy and degraded shapes — so a shape drift is caught in CI,
+ * not by a client seeing an "Output validation error".
+ *
+ * Top-level parse is `.strict()` (stricter than the SDK's strip) so the schema
+ * must DECLARE every key a handler emits — otherwise structuredContent would
+ * silently drop it. Nested domain objects (match/view/tables/signals) stay
+ * passthrough on purpose, so this doesn't have to mirror every core field.
+ */
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+  allFixtures,
+  FakeMarketProvider,
+  type GroupStandings,
+  type Match,
+  type ProviderAdapter,
+} from '@claudinho/core';
+import {
+  toolGetBracket,
+  toolGetLive,
+  toolGetMarketSignal,
+  toolGetMatch,
+  toolGetNextFixture,
+  toolGetShareSnippet,
+  toolGetStandings,
+  toolGetToday,
+} from '../src/tools';
+import { OUTPUT_SCHEMAS } from '../src/server';
+
+// In-tournament clock: keeps "now"-relative gates (market relevance, next
+// fixture) deterministic forever, including after the tournament ends.
+const TEST_NOW = new Date('2026-06-13T12:00:00Z');
+
+function liveMatch(over: Partial<Match> = {}): Match {
+  return {
+    id: '760415',
+    stage: 'GROUP',
+    group: 'A',
+    kickoff: '2026-06-11T19:00Z',
+    venue: 'Estadio Banorte',
+    city: 'Mexico City',
+    country: 'Mexico',
+    home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+    away: { code: 'RSA', name: 'South Africa', flag: '🇿🇦' },
+    status: 'LIVE',
+    minute: 67,
+    score: { home: 1, away: 0 },
+    updatedAt: '2026-06-11T20:07Z',
+    ...over,
+  };
+}
+
+function fakeAdapter(opts: {
+  live?: Match[];
+  byDate?: Match[];
+  window?: Match[];
+  throws?: boolean;
+  standings?: GroupStandings[];
+}): ProviderAdapter {
+  return {
+    name: 'fake',
+    capabilities: { push: false, latencyHintSec: 0 },
+    async fetchByDate() {
+      if (opts.throws) throw new Error('network down');
+      return opts.byDate ?? [];
+    },
+    async fetchLive() {
+      if (opts.throws) throw new Error('network down');
+      return opts.live ?? [];
+    },
+    async fetchWindow() {
+      if (opts.throws) throw new Error('network down');
+      return opts.window ?? opts.live ?? opts.byDate ?? [];
+    },
+    ...(opts.standings
+      ? {
+          async fetchStandings() {
+            if (opts.throws) throw new Error('network down');
+            return opts.standings as GroupStandings[];
+          },
+        }
+      : {}),
+  };
+}
+
+const A_TABLE: GroupStandings = {
+  group: 'A',
+  rows: [
+    { team: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' }, played: 1, won: 1, drawn: 0, lost: 0, goalsFor: 2, goalsAgainst: 0, goalDiff: 2, points: 3 },
+    { team: { code: 'KOR', name: 'South Korea', flag: '🇰🇷' }, played: 1, won: 1, drawn: 0, lost: 0, goalsFor: 2, goalsAgainst: 1, goalDiff: 1, points: 3 },
+  ],
+};
+
+const synth = () => new FakeMarketProvider({ synthesize: true, now: TEST_NOW });
+
+/** A fixture still upcoming at TEST_NOW — its market read is relevant. */
+const upcoming = (): Match =>
+  allFixtures().find(
+    (m) => m.status === 'SCHEDULED' && Date.parse(m.kickoff) > TEST_NOW.getTime(),
+  )!;
+
+/** Parse `data` against the tool's advertised schema; fail loud with details. */
+function expectValid(tool: keyof typeof OUTPUT_SCHEMAS, data: unknown) {
+  const res = z.object(OUTPUT_SCHEMAS[tool]).strict().safeParse(data);
+  if (!res.success) {
+    throw new Error(
+      `${tool} data does not match its outputSchema:\n${JSON.stringify(res.error.issues, null, 2)}\n\nData:\n${JSON.stringify(data, null, 2)}`,
+    );
+  }
+  expect(res.success).toBe(true);
+}
+
+describe('MCP tool output schemas', () => {
+  it('OUTPUT_SCHEMAS covers exactly the eight tools', () => {
+    expect(Object.keys(OUTPUT_SCHEMAS).sort()).toEqual(
+      [
+        'get_bracket',
+        'get_live',
+        'get_market_signal',
+        'get_match',
+        'get_next_fixture',
+        'get_share_snippet',
+        'get_standings',
+        'get_today',
+      ].sort(),
+    );
+  });
+
+  describe('get_today', () => {
+    it('healthy (with matches + market signals)', async () => {
+      const up = upcoming();
+      const r = await toolGetToday({
+        date: up.kickoff.slice(0, 10),
+        adapter: fakeAdapter({ window: [up] }),
+        marketProvider: synth(),
+        now: TEST_NOW,
+      });
+      expectValid('get_today', r.data);
+    });
+    it('degraded (feed down)', async () => {
+      const r = await toolGetToday({
+        date: '2026-06-13',
+        adapter: fakeAdapter({ throws: true }),
+        marketProvider: synth(),
+        now: TEST_NOW,
+      });
+      expectValid('get_today', r.data);
+    });
+  });
+
+  describe('get_live', () => {
+    it('healthy (a live match)', async () => {
+      const r = await toolGetLive({ adapter: fakeAdapter({ live: [liveMatch()] }) });
+      expectValid('get_live', r.data);
+    });
+    it('empty', async () => {
+      const r = await toolGetLive({ adapter: fakeAdapter({ live: [] }) });
+      expectValid('get_live', r.data);
+    });
+    it('degraded', async () => {
+      const r = await toolGetLive({ adapter: fakeAdapter({ throws: true }) });
+      expectValid('get_live', r.data);
+    });
+  });
+
+  describe('get_match', () => {
+    it('found (live, market-relevant)', async () => {
+      const r = await toolGetMatch({
+        id: '760415',
+        adapter: fakeAdapter({ window: [liveMatch()] }),
+        marketProvider: synth(),
+        now: TEST_NOW,
+      });
+      expectValid('get_match', r.data);
+    });
+    it('not found', async () => {
+      const r = await toolGetMatch({ id: 'nope', adapter: fakeAdapter({ window: [] }) });
+      expectValid('get_match', r.data);
+    });
+    it('degraded', async () => {
+      const r = await toolGetMatch({ id: '760415', adapter: fakeAdapter({ throws: true }) });
+      expectValid('get_match', r.data);
+    });
+  });
+
+  describe('get_standings', () => {
+    it('one group (live)', async () => {
+      const r = await toolGetStandings({ group: 'A', adapter: fakeAdapter({ standings: [A_TABLE] }) });
+      expectValid('get_standings', r.data);
+    });
+    it('all groups (live)', async () => {
+      const r = await toolGetStandings({ adapter: fakeAdapter({ standings: [A_TABLE] }) });
+      expectValid('get_standings', r.data);
+    });
+    it('degraded roster (no standings feed)', async () => {
+      const r = await toolGetStandings({ group: 'A', adapter: fakeAdapter({}) });
+      expectValid('get_standings', r.data);
+    });
+    it('unknown group (empty)', async () => {
+      const r = await toolGetStandings({ group: 'z', adapter: fakeAdapter({ standings: [A_TABLE] }) });
+      expectValid('get_standings', r.data);
+    });
+  });
+
+  describe('get_bracket', () => {
+    it('resolved view', async () => {
+      const r = await toolGetBracket({ adapter: fakeAdapter({ window: [] }), now: TEST_NOW });
+      expectValid('get_bracket', r.data);
+    });
+    it('filtered stage', async () => {
+      const r = await toolGetBracket({ stage: 'R32', adapter: fakeAdapter({ window: [] }), now: TEST_NOW });
+      expectValid('get_bracket', r.data);
+    });
+    it('unknown stage (view: null)', async () => {
+      const r = await toolGetBracket({ stage: 'ZZ', adapter: fakeAdapter({}) });
+      expectValid('get_bracket', r.data);
+    });
+  });
+
+  describe('get_next_fixture', () => {
+    it('found (static group fixture)', async () => {
+      const r = await toolGetNextFixture({
+        team: upcoming().home.code,
+        adapter: fakeAdapter({ window: [] }),
+        now: TEST_NOW,
+      });
+      expectValid('get_next_fixture', r.data);
+    });
+    it('not found', async () => {
+      const r = await toolGetNextFixture({ team: 'ZZZ', adapter: fakeAdapter({ window: [] }), now: TEST_NOW });
+      expectValid('get_next_fixture', r.data);
+    });
+    it('degraded', async () => {
+      const r = await toolGetNextFixture({ team: 'MEX', adapter: fakeAdapter({ throws: true }), now: TEST_NOW });
+      expectValid('get_next_fixture', r.data);
+    });
+  });
+
+  describe('get_market_signal', () => {
+    it('by match id', async () => {
+      const up = upcoming();
+      const r = await toolGetMarketSignal({
+        matchId: up.id,
+        adapter: fakeAdapter({ window: [up] }),
+        marketProvider: synth(),
+        now: TEST_NOW,
+      });
+      expectValid('get_market_signal', r.data);
+    });
+    it('unknown match id (null signal)', async () => {
+      const r = await toolGetMarketSignal({ matchId: 'nope', adapter: fakeAdapter({ window: [] }), marketProvider: synth() });
+      expectValid('get_market_signal', r.data);
+    });
+    it("by team (next fixture)", async () => {
+      const r = await toolGetMarketSignal({
+        team: upcoming().home.code,
+        adapter: fakeAdapter({ window: [] }),
+        marketProvider: synth(),
+        now: TEST_NOW,
+      });
+      expectValid('get_market_signal', r.data);
+    });
+    it('by date', async () => {
+      const up = upcoming();
+      const r = await toolGetMarketSignal({
+        date: up.kickoff.slice(0, 10),
+        adapter: fakeAdapter({ window: [up] }),
+        marketProvider: synth(),
+        now: TEST_NOW,
+      });
+      expectValid('get_market_signal', r.data);
+    });
+  });
+
+  describe('get_share_snippet', () => {
+    it('live', async () => {
+      const r = await toolGetShareSnippet({ live: true, adapter: fakeAdapter({ live: [liveMatch()] }) });
+      expectValid('get_share_snippet', r.data);
+    });
+    it('group standings (live)', async () => {
+      const r = await toolGetShareSnippet({ group: 'A', adapter: fakeAdapter({ standings: [A_TABLE] }) });
+      expectValid('get_share_snippet', r.data);
+    });
+    it('group standings (degraded roster)', async () => {
+      const r = await toolGetShareSnippet({ group: 'A', adapter: fakeAdapter({}) });
+      expectValid('get_share_snippet', r.data);
+    });
+    it('bracket', async () => {
+      const r = await toolGetShareSnippet({ bracket: true, adapter: fakeAdapter({ window: [] }), now: TEST_NOW });
+      expectValid('get_share_snippet', r.data);
+    });
+    it('bracket filtered stage', async () => {
+      const r = await toolGetShareSnippet({ bracket: true, knockoutStage: 'R32', adapter: fakeAdapter({ window: [] }), now: TEST_NOW });
+      expectValid('get_share_snippet', r.data);
+    });
+    it('bracket unknown stage (view: null)', async () => {
+      const r = await toolGetShareSnippet({ bracket: true, knockoutStage: 'ZZ', adapter: fakeAdapter({}) });
+      expectValid('get_share_snippet', r.data);
+    });
+    it('match by id', async () => {
+      const r = await toolGetShareSnippet({
+        matchId: '760415',
+        adapter: fakeAdapter({ window: [liveMatch()] }),
+        marketProvider: synth(),
+        now: TEST_NOW,
+      });
+      expectValid('get_share_snippet', r.data);
+    });
+    it("team next fixture", async () => {
+      const r = await toolGetShareSnippet({
+        team: upcoming().home.code,
+        adapter: fakeAdapter({ window: [] }),
+        marketProvider: synth(),
+        now: TEST_NOW,
+      });
+      expectValid('get_share_snippet', r.data);
+    });
+    it('today (date default)', async () => {
+      const up = upcoming();
+      const r = await toolGetShareSnippet({
+        date: up.kickoff.slice(0, 10),
+        adapter: fakeAdapter({ window: [up] }),
+        marketProvider: synth(),
+        now: TEST_NOW,
+      });
+      expectValid('get_share_snippet', r.data);
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds a declared **`outputSchema`** + **`structuredContent`** to all 8 MCP tools (`get_today`, `get_live`, `get_match`, `get_standings`, `get_bracket`, `get_next_fixture`, `get_market_signal`, `get_share_snippet`). Clients now get machine-validated structured output, not just a text-embedded JSON block — and the Smithery-scored `.mcpb` manifest carries the schema.

## Why

Smithery scores capability quality; "Output schemas 0/8" was the largest remaining gap (~+10 pts after the annotations pass in #69). Beyond the score, a declared output schema is the correct MCP contract: clients can parse structured data reliably and the SDK validates every response against it.

## How

- **`packages/mcp/src/server.ts`** — 8 per-tool Zod raw-shape schemas + shared shapes (`matchOut`, `anyObj`, `teamRef`, `scorePair`, `src`). Deliberately permissive: `.passthrough()` on nested domain objects (so no core field is stripped and forward-compat additions never break validation); every branch-specific top-level key is `.optional()`. `toContent` now returns `structuredContent: r.data`. Schemas exported as `OUTPUT_SCHEMAS` for the guard test.
- **`packages/mcp/scripts/build-mcpb.mjs`** — inject each tool's live `outputSchema` into the packed manifest (Smithery scores the manifest, so an in-process schema alone wouldn't count).
- **`packages/mcp/test/output-schema.test.ts`** (new, +32 cases) — validates every handler's `data` (healthy **and** degraded shapes, via fake adapters) against the schema its tool advertises. Top-level parse is `.strict()` (stricter than the SDK's strip) so the schema must declare every emitted key — catching fidelity loss, not just crashes.
- **`packages/mcp/README.md`** — the "structured JSON" line now notes it's validated against each tool's `outputSchema`.

## Verified

- `pnpm -r build && typecheck && test && lint` green (mcp 75→**107** tests).
- `pnpm release:qa` — 6/6 tripwires pass, 0 skipped.
- **Real stdio handshake:** all 8 tools expose `outputSchema` in `tools/list`; `tools/call` returns valid `structuredContent` (no JSON-RPC validation error) — checked on the **live ESPN feed** (`get_today`, `get_next_fixture MEX`, `get_standings A`, `share bracket`) and on fail-closed/degraded shapes.
- `.mcpb` packed manifest carries `inputSchema` + `outputSchema` + `annotations` on all 8 tools.

## MCP-affecting

Yes — tool output shape changes. On merge: tag `v0.8.16` → publish.yml (OIDC), then `server.json` Registry republish + rebuild `.mcpb` for a Smithery re-publish.

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>
