### PR TITLE
ci: guard hardening — stdio smoke, OS matrix, latency budget, pack guard (F5 Batch 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ concurrency:
 permissions:
   contents: read
 
+# Actions are pinned to full commit SHAs (not tags): a re-pointed tag on a
+# third-party action would otherwise execute arbitrary code in these jobs — and
+# publish.yml (same pins) holds the npm OIDC credential. Dependabot keeps SHA
+# pins updated; the trailing comment records the human-readable version.
+
 jobs:
   build-test:
     name: build · typecheck · test (Node ${{ matrix.node }})
@@ -25,9 +30,9 @@ jobs:
         # — that floor is verified by the `runtime-node20` job below.
         node: [22, 24]
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6 # reads pnpm version from package.json "packageManager"
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6 — reads pnpm version from package.json "packageManager"
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -40,14 +45,25 @@ jobs:
       - run: pnpm -r test
       - run: pnpm lint # Biome (real linter, replaces the former no-op)
 
+      # The MCP server over REAL stdio — the transport every install channel
+      # (Registry npx, Smithery, Cursor plugin) actually launches, which the
+      # vitest suite never exercises (it imports handlers in-process).
+      - name: MCP server stdio smoke
+        run: pnpm -F @claudinho/mcp smoke:stdio
+
+      # Tarball contents: nothing ships beyond dist/README/LICENSE, never a
+      # .mcpb or anything under docs/ (and git must track nothing under docs/).
+      - name: Pack contents guard
+        run: node scripts/check-pack.mjs
+
   runtime-node20:
     name: runtime smoke (Node 20 engines floor)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       # Build with a pnpm-supported Node...
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm
@@ -56,7 +72,7 @@ jobs:
       # ...then run the built artifacts under Node 20 to confirm the shipped
       # code actually works on the version we advertise (engines.node >= 20).
       # Uses offline-only commands (bundled schedule, no network).
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
       - name: Exercise the built CLI on Node 20
@@ -66,14 +82,75 @@ jobs:
           node packages/cli/dist/index.js table A
           node packages/cli/dist/index.js vibe
           echo "Node 20 runtime OK"
+      # The engines floor applies to the MCP server and the statusline too —
+      # plain `node` invocations (pnpm itself needs >= 22.13, so no pnpm here).
+      - name: MCP server stdio smoke on Node 20
+        run: node packages/mcp/scripts/stdio-smoke.mjs
+      - name: Statusline smoke on Node 20 (seeded cache, offline)
+        run: node scripts/smoke-statusline.mjs
+
+  os-matrix:
+    # The CLI ships to macOS/Windows users (statusline installs on both), but
+    # nothing had ever EXECUTED on them in CI — cache tmp+rename, the detached
+    # refresher spawn, and ~/.claude writes are all platform-sensitive.
+    name: build · test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm -r build
+      - run: pnpm -r test
+      - name: Offline CLI smoke (bundled schedule, no network)
+        run: |
+          node packages/cli/dist/index.js next MEX
+          node packages/cli/dist/index.js table A
+      - name: Statusline smoke (seeded cache)
+        run: node scripts/smoke-statusline.mjs
+      - name: MCP server stdio smoke
+        run: node packages/mcp/scripts/stdio-smoke.mjs
+
+  coverage:
+    # Visibility only, never a gate: publishes per-package V8 coverage so blind
+    # spots are inspectable (several shipped bugs were "the branch nobody
+    # rendered"). Thresholds are a deliberate non-goal for now.
+    name: coverage (non-gating)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm -r build
+      - name: Test with V8 coverage
+        # No `--` separator: pnpm forwards unrecognized options to the script;
+        # with `--` the flags never reach vitest (verified locally).
+        run: pnpm -r test --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-summaries
+          path: packages/*/coverage/coverage-summary.json
+          if-no-files-found: warn
 
   audit:
     name: audit (shipped deps)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
   build-test:
     name: build · typecheck · test (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # a hung test must fail in minutes, not burn the 6h default
     strategy:
       fail-fast: false
       matrix:
@@ -59,6 +60,7 @@ jobs:
   runtime-node20:
     name: runtime smoke (Node 20 engines floor)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
@@ -95,6 +97,9 @@ jobs:
     # refresher spawn, and ~/.claude writes are all platform-sensitive.
     name: build · test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # The first windows leg hung for an hour on a blocking stdin read — cap the
+    # blast radius of any future platform hang.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -124,6 +129,7 @@ jobs:
     # rendered"). Thresholds are a deliberate non-goal for now.
     name: coverage (non-gating)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     continue-on-error: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -147,6 +153,7 @@ jobs:
   audit:
     name: audit (shipped deps)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      # SHA-pinned (not tag-pinned): this job holds `id-token: write` — the npm
+      # trusted-publishing credential for all three packages — so a re-pointed
+      # action tag must not be able to execute here. Dependabot updates SHA pins.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "lint": "biome lint .",
     "typecheck": "pnpm -r typecheck",
     "dev": "pnpm -r --parallel dev",
-    "release:qa": "bash scripts/release-qa.sh"
+    "release:qa": "bash scripts/release-qa.sh",
+    "check:pack": "node scripts/check-pack.mjs",
+    "smoke:statusline": "node scripts/smoke-statusline.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.1"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@claudinho/core": "workspace:*",
     "@types/node": "^22.20.0",
+    "@vitest/coverage-v8": "^4.1.9",
     "tsup": "^8.0.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.9"

--- a/packages/cli/src/cache.ts
+++ b/packages/cli/src/cache.ts
@@ -9,14 +9,15 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
-  renameSync,
   rmSync,
   statSync,
   writeSync,
 } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Match } from '@claudinho/core';
+import { cacheDir, writeFileAtomic } from './paths';
+
+export { cacheDir } from './paths';
 
 /** The cached snapshot. `live` holds in-progress matches at `updatedAt`. */
 export interface CacheState {
@@ -39,11 +40,6 @@ export interface CacheState {
 }
 
 const LOCK_STALE_MS = 60_000;
-
-export function cacheDir(): string {
-  const base = process.env.XDG_CACHE_HOME || join(homedir(), '.cache');
-  return join(base, 'claudinho');
-}
 
 export function cachePath(): string {
   return join(cacheDir(), 'state.json');
@@ -77,21 +73,7 @@ export function readCurrentState(
 
 /** Atomically write the cached state. */
 export function writeState(state: CacheState): void {
-  const dir = cacheDir();
-  mkdirSync(dir, { recursive: true });
-  const tmp = join(dir, `state.${process.pid}.tmp`);
-  writeFileSync_(tmp, JSON.stringify(state));
-  renameSync(tmp, cachePath()); // atomic on the same filesystem
-}
-
-// Small helper to avoid importing writeFileSync separately from writeSync use.
-function writeFileSync_(path: string, data: string): void {
-  const fd = openSync(path, 'w');
-  try {
-    writeSync(fd, data);
-  } finally {
-    closeSync(fd);
-  }
+  writeFileAtomic(cachePath(), JSON.stringify(state));
 }
 
 /** Age of the cache in ms (Infinity if absent/unparseable). */

--- a/packages/cli/src/i18n.ts
+++ b/packages/cli/src/i18n.ts
@@ -1,7 +1,5 @@
 /** Minimal message catalog. Keys are stable; values localized. */
-type Dict = Record<string, string>;
-
-const EN: Dict = {
+const EN = {
   'today.title': "Today's matches",
   'today.on': 'Matches',
   'today.none': 'No matches scheduled for this date.',
@@ -38,6 +36,13 @@ const EN: Dict = {
   'warn.lang': 'Unsupported language {lang}; using English. (supported: en, es, pt, fr)',
   disclaimer: 'Not affiliated with FIFA or Anthropic.',
 };
+
+/**
+ * Every locale must define exactly the EN key set — a missing or mistyped
+ * es/pt/fr key fails `tsc` instead of silently rendering mid-sentence English
+ * at runtime (the fallback below stays, but only for genuinely unknown keys).
+ */
+type Dict = Record<keyof typeof EN, string>;
 
 const ES: Dict = {
   'today.title': 'Partidos de hoy',
@@ -157,9 +162,11 @@ const CATALOGS: Record<string, Dict> = { en: EN, es: ES, pt: PT, fr: FR };
 
 /** Translator bound to a locale, with simple {placeholder} interpolation. */
 export function makeT(lang: string) {
-  const dict = CATALOGS[lang] ?? EN;
+  // Widen for lookup: callers pass arbitrary string keys (unknown → key echo).
+  const dict: Record<string, string> = CATALOGS[lang] ?? EN;
+  const en: Record<string, string> = EN;
   return (key: string, vars?: Record<string, string>): string => {
-    let s = dict[key] ?? EN[key] ?? key;
+    let s = dict[key] ?? en[key] ?? key;
     // replaceAll (matching core's t()) so a repeated placeholder fills every slot.
     if (vars) for (const [k, v] of Object.entries(vars)) s = s.replaceAll(`{${k}}`, v);
     return s;

--- a/packages/cli/src/install.ts
+++ b/packages/cli/src/install.ts
@@ -3,15 +3,10 @@
  * Claude Code or Cursor CLI statuslines. Safe: preserves existing settings,
  * backs up before overwriting, and refuses to clobber unparseable files.
  */
-import {
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync,
-} from 'node:fs';
+import { copyFileSync, existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
+import { writeFileAtomic } from './paths';
 
 export type StatuslineTarget = 'claude' | 'cursor';
 
@@ -137,8 +132,8 @@ export function initStatuslineFor(
 
   backupOnce(path);
   settings.statusLine = sl;
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify(settings, null, 2) + '\n', 'utf8');
+  // Atomic (tmp + rename): a crash mid-write must never truncate the user's settings.
+  writeFileAtomic(path, JSON.stringify(settings, null, 2) + '\n');
   const surface = target === 'cursor' ? 'Cursor CLI statusline' : 'Statusline';
   return {
     action: 'written',
@@ -213,8 +208,7 @@ export function initHook(opts: InitOpts = {}): InitResult {
   const hooks = settings.hooks as Record<string, ClaudeHookMatcher[]>;
   hooks[CLAUDE_HOOK_EVENT] ??= [];
   hooks[CLAUDE_HOOK_EVENT].push({ hooks: [{ type: 'command', command }] });
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify(settings, null, 2) + '\n', 'utf8');
+  writeFileAtomic(path, JSON.stringify(settings, null, 2) + '\n');
   return {
     action: 'written',
     path,

--- a/packages/cli/src/marketCache.ts
+++ b/packages/cli/src/marketCache.ts
@@ -10,10 +10,10 @@
  * appear as kickoff approaches). Best-effort + tolerant: a corrupt/absent file
  * reads as empty, and writes never throw.
  */
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { MarketSignal } from '@claudinho/core';
+import { cacheDir, writeFileAtomic } from './paths';
 
 const POSITIVE_TTL_MS = 10 * 60_000;
 const NEGATIVE_TTL_MS = 3 * 60_000;
@@ -27,11 +27,6 @@ interface MarketCacheFile {
   source: string;
   competition: string;
   entries: Record<string, CacheEntry>;
-}
-
-function cacheDir(): string {
-  const base = process.env.XDG_CACHE_HOME || join(homedir(), '.cache');
-  return join(base, 'claudinho');
 }
 
 function cachePath(): string {
@@ -99,10 +94,7 @@ export function writeMarketCache(
     for (const id of attempted) {
       base.entries[id] = { fetchedAt, signal: fetched.get(id) ?? null };
     }
-    mkdirSync(cacheDir(), { recursive: true });
-    const tmp = join(cacheDir(), `market-signals.${process.pid}.tmp`);
-    writeFileSync(tmp, JSON.stringify(base));
-    renameSync(tmp, cachePath()); // atomic on the same filesystem
+    writeFileAtomic(cachePath(), JSON.stringify(base));
   } catch {
     /* best-effort; never break a command */
   }

--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -9,7 +9,13 @@ import { closeSync, mkdirSync, openSync, renameSync, writeSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
-/** `$XDG_CACHE_HOME/claudinho`, falling back to `~/.cache/claudinho`. */
+/**
+ * `$XDG_CACHE_HOME/claudinho`, falling back to `~/.cache/claudinho`.
+ *
+ * Windows deliberately gets the same `~/.cache` fallback (not %LOCALAPPDATA%):
+ * switching would relocate existing installs' caches mid-tournament. Revisit
+ * once the Windows CI leg is established (with a read-old-location fallback).
+ */
 export function cacheDir(): string {
   const base = process.env.XDG_CACHE_HOME || join(homedir(), '.cache');
   return join(base, 'claudinho');

--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared filesystem helpers for the CLI: the single home for the claudinho
+ * cache directory (previously duplicated across cache/marketCache/starNudge)
+ * and an atomic write for files a reader may observe mid-write (cache
+ * snapshots, ~/.claude settings). tmp + rename on the same filesystem — a
+ * crash can abandon a .tmp but never leave a truncated target.
+ */
+import { closeSync, mkdirSync, openSync, renameSync, writeSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+/** `$XDG_CACHE_HOME/claudinho`, falling back to `~/.cache/claudinho`. */
+export function cacheDir(): string {
+  const base = process.env.XDG_CACHE_HOME || join(homedir(), '.cache');
+  return join(base, 'claudinho');
+}
+
+/** Atomically write `data` to `path` (utf8), creating parent dirs as needed. */
+export function writeFileAtomic(path: string, data: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.tmp`;
+  const fd = openSync(tmp, 'w');
+  try {
+    writeSync(fd, data);
+  } finally {
+    closeSync(fd);
+  }
+  renameSync(tmp, path); // atomic on the same filesystem
+}

--- a/packages/cli/src/starNudge.ts
+++ b/packages/cli/src/starNudge.ts
@@ -6,9 +6,9 @@
  * suppressible with CLAUDINHO_NO_STAR. Everything here is best-effort and never
  * throws — a CTA must never break or slow a command.
  */
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { cacheDir, writeFileAtomic } from './paths';
 
 /** Canonical repo URL — the single place every star CTA points to. */
 export const REPO_URL = 'https://github.com/arturogarrido/claudinho';
@@ -16,8 +16,7 @@ export const REPO_URL = 'https://github.com/arturogarrido/claudinho';
 const NUDGE_EVERY = 5;
 
 function counterPath(): string {
-  const base = process.env.XDG_CACHE_HOME || join(homedir(), '.cache');
-  return join(base, 'claudinho', 'runs.json');
+  return join(cacheDir(), 'runs.json');
 }
 
 /** Show the star nudge on every Nth interactive run. Pure → unit-testable. */
@@ -40,8 +39,7 @@ export function bumpRunCount(path: string = counterPath()): number | undefined {
       count = 0; // missing/corrupt → start fresh
     }
     count += 1;
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, JSON.stringify({ count }), 'utf8');
+    writeFileAtomic(path, JSON.stringify({ count }));
     return count;
   } catch {
     return undefined;

--- a/packages/cli/test/hotpath-latency.test.ts
+++ b/packages/cli/test/hotpath-latency.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { writeState } from '../src/cache';
 import { cmdHook, cmdPrompt } from '../src/commands';
 import type { CliConfig } from '../src/config';
+import * as cursorPayload from '../src/cursorPayload';
 import { makeT } from '../src/i18n';
 
 // Only `spawn` is stubbed — `execFileSync` (used to run the real binary below)
@@ -86,6 +87,10 @@ beforeEach(() => {
   delete process.env.CLAUDINHO_COMPETITION;
   delete process.env.CLAUDINHO_TEAM;
   process.env.CLAUDINHO_FLAGS = 'on';
+  // In-process cmdPrompt must never read real stdin — readFileSync(0) hangs on
+  // Windows workers (open writerless pipe). The spawned-binary test below
+  // exercises the real drain with an explicit EOF (`input: ''`).
+  vi.spyOn(cursorPayload, 'readCursorPayload').mockReturnValue(undefined);
   vi.mocked(spawn).mockClear();
 });
 afterEach(() => {

--- a/packages/cli/test/hotpath-latency.test.ts
+++ b/packages/cli/test/hotpath-latency.test.ts
@@ -1,0 +1,147 @@
+/**
+ * HOT-PATH BUDGET GUARD — the <150ms statusline constraint, made executable.
+ *
+ * Two contracts:
+ *  1. The built `prompt` binary, fed a fresh seeded cache, completes well inside
+ *     an order-of-magnitude CI bound. The bound is deliberately loose (CI runners
+ *     are noisy); its job is to catch a heavy top-level import or accidental
+ *     sync work sneaking onto the hot path, not to certify 150ms.
+ *  2. In-process, `cmdPrompt`/`cmdHook` with a FRESH cache perform zero network
+ *     calls and spawn zero refreshers — the hot path is cache-read + render only.
+ */
+import { execFileSync, spawn } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Match } from '@claudinho/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { writeState } from '../src/cache';
+import { cmdHook, cmdPrompt } from '../src/commands';
+import type { CliConfig } from '../src/config';
+import { makeT } from '../src/i18n';
+
+// Only `spawn` is stubbed — `execFileSync` (used to run the real binary below)
+// stays real via the importOriginal spread.
+vi.mock('node:child_process', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('node:child_process')>();
+  return { ...mod, spawn: vi.fn(() => ({ unref() {} })) };
+});
+
+const DIST = join(fileURLToPath(new URL('.', import.meta.url)), '..', 'dist', 'index.js');
+
+function cfg(over: Partial<CliConfig> = {}): CliConfig {
+  return {
+    lang: 'en',
+    tz: undefined,
+    json: false,
+    color: false,
+    source: 'espn',
+    flavor: 'off',
+    markets: true,
+    ...over,
+  };
+}
+
+function liveMex(now: Date): Match {
+  return {
+    id: '760491',
+    stage: 'GROUP',
+    group: 'A',
+    kickoff: now.toISOString(),
+    venue: 'Estadio Banorte',
+    home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+    away: { code: 'ECU', name: 'Ecuador', flag: '🇪🇨' },
+    status: 'LIVE',
+    minute: 30,
+    score: { home: 1, away: 0 },
+    updatedAt: now.toISOString(),
+  };
+}
+
+/** Fresh on BOTH cadences (live + fixtures) → the hot path has nothing to refresh. */
+function seedFreshCache(): void {
+  const now = new Date();
+  writeState({
+    updatedAt: now.toISOString(),
+    live: [liveMex(now)],
+    degraded: false,
+    source: 'espn',
+    competition: 'fifa.world',
+    fixtures: [liveMex(now)],
+    fixturesUpdatedAt: now.toISOString(),
+  });
+}
+
+let dir: string;
+const origEnv = {
+  cache: process.env.XDG_CACHE_HOME,
+  comp: process.env.CLAUDINHO_COMPETITION,
+  team: process.env.CLAUDINHO_TEAM,
+  flags: process.env.CLAUDINHO_FLAGS,
+};
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'claudinho-latency-'));
+  process.env.XDG_CACHE_HOME = dir;
+  delete process.env.CLAUDINHO_COMPETITION;
+  delete process.env.CLAUDINHO_TEAM;
+  process.env.CLAUDINHO_FLAGS = 'on';
+  vi.mocked(spawn).mockClear();
+});
+afterEach(() => {
+  const { cache, comp, team, flags } = origEnv;
+  if (cache === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = cache;
+  if (comp === undefined) delete process.env.CLAUDINHO_COMPETITION;
+  else process.env.CLAUDINHO_COMPETITION = comp;
+  if (team === undefined) delete process.env.CLAUDINHO_TEAM;
+  else process.env.CLAUDINHO_TEAM = team;
+  if (flags === undefined) delete process.env.CLAUDINHO_FLAGS;
+  else process.env.CLAUDINHO_FLAGS = flags;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('hot path performs no I/O beyond the cache read (in-process)', () => {
+  it('cmdPrompt/cmdHook with a fresh cache: zero fetches, zero refresher spawns', () => {
+    seedFreshCache();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const outSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    try {
+      cmdPrompt({ cfg: cfg(), t: makeT('en') });
+      cmdHook({ cfg: cfg(), t: makeT('en') });
+    } finally {
+      outSpy.mockRestore();
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(spawn)).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});
+
+describe.skipIf(!existsSync(DIST))('built `prompt` stays inside the latency budget', () => {
+  // Loose bounds absorb CI-runner noise while still catching an order-of-magnitude
+  // regression (the real budget is <150ms; warm p50 measured ~50ms on dev hardware).
+  const BOUND_MS = process.platform === 'win32' ? 1500 : 500;
+
+  it(`median of 10 runs < ${BOUND_MS}ms and renders the seeded match`, () => {
+    seedFreshCache();
+    const env = { ...process.env }; // carries XDG_CACHE_HOME + CLAUDINHO_FLAGS from beforeEach
+    const times: number[] = [];
+    let lastOut = '';
+    for (let i = 0; i < 10; i++) {
+      const t0 = performance.now();
+      lastOut = execFileSync(process.execPath, [DIST, 'prompt'], {
+        env,
+        encoding: 'utf8',
+        input: '', // immediate stdin EOF — the Cursor-payload drain must not block
+        timeout: 15_000,
+      });
+      times.push(performance.now() - t0);
+    }
+    expect(lastOut).toContain('🇲🇽'); // it actually rendered from the seeded cache
+    const median = times.sort((a, b) => a - b)[Math.floor(times.length / 2)] ?? Infinity;
+    expect(median, `run times: ${times.map((t) => t.toFixed(0)).join(', ')}ms`).toBeLessThan(
+      BOUND_MS,
+    );
+  });
+});

--- a/packages/cli/test/hotpath.test.ts
+++ b/packages/cli/test/hotpath.test.ts
@@ -64,6 +64,13 @@ beforeEach(() => {
   // Pin flags on so these assertions hold regardless of the host terminal
   // (the flag auto-detect would otherwise switch to codes under e.g. Warp).
   process.env.CLAUDINHO_FLAGS = 'on';
+  // Never touch real stdin from in-process cmdPrompt calls: readFileSync(0)
+  // blocks FOREVER on Windows when the vitest worker's stdin is an open,
+  // writerless pipe (froze the first windows-latest CI leg for an hour). The
+  // real stdin drain is exercised by the built-binary run in
+  // hotpath-latency.test.ts, which provides an explicit EOF. The Cursor-payload
+  // test below re-mocks this with its own payload.
+  vi.spyOn(cursorPayload, 'readCursorPayload').mockReturnValue(undefined);
   writes = [];
   outSpy = vi.spyOn(process.stdout, 'write').mockImplementation((c: unknown) => {
     writes.push(String(c));

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -69,18 +69,24 @@ describe('CURSOR_MCP_SNIPPET', () => {
 });
 
 // Write-path integration: `init claude` must write BOTH the statusline and the
-// hook to settings.json (parity bundle), and stay idempotent. Isolated via $HOME
-// so it never touches the real ~/.claude (os.homedir() reads $HOME on POSIX).
+// hook to settings.json (parity bundle), and stay idempotent. Isolated via
+// $HOME (POSIX) AND %USERPROFILE% (os.homedir() reads USERPROFILE on Windows —
+// HOME alone let the first windows-latest CI leg write to the runner's real
+// ~/.claude) so it never touches the real settings.
 describe('cmdInitClaude — write path (isolated HOME)', () => {
   let dir: string;
   const ORIG_HOME = process.env.HOME;
+  const ORIG_USERPROFILE = process.env.USERPROFILE;
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'claudinho-init-'));
     process.env.HOME = dir;
+    process.env.USERPROFILE = dir;
   });
   afterEach(() => {
     if (ORIG_HOME === undefined) delete process.env.HOME;
     else process.env.HOME = ORIG_HOME;
+    if (ORIG_USERPROFILE === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = ORIG_USERPROFILE;
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -115,16 +121,20 @@ describe('cmdInitClaude — write path (isolated HOME)', () => {
 describe('printInitStarCta gating (via cmdInitClaude, isolated HOME)', () => {
   let dir: string;
   const ORIG_HOME = process.env.HOME;
+  const ORIG_USERPROFILE = process.env.USERPROFILE;
   const ORIG_NO_STAR = process.env.CLAUDINHO_NO_STAR;
   const ORIG_TTY = process.stdout.isTTY;
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'claudinho-cta-'));
     process.env.HOME = dir;
+    process.env.USERPROFILE = dir; // homedir() reads USERPROFILE on Windows
     delete process.env.CLAUDINHO_NO_STAR;
   });
   afterEach(() => {
     if (ORIG_HOME === undefined) delete process.env.HOME;
     else process.env.HOME = ORIG_HOME;
+    if (ORIG_USERPROFILE === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = ORIG_USERPROFILE;
     if (ORIG_NO_STAR === undefined) delete process.env.CLAUDINHO_NO_STAR;
     else process.env.CLAUDINHO_NO_STAR = ORIG_NO_STAR;
     process.stdout.isTTY = ORIG_TTY;

--- a/packages/cli/test/paths.test.ts
+++ b/packages/cli/test/paths.test.ts
@@ -1,0 +1,41 @@
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cacheDir, writeFileAtomic } from '../src/paths';
+
+describe('writeFileAtomic', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'claudinho-paths-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('creates parent dirs, writes the content, and leaves no tmp file behind', () => {
+    const target = join(dir, 'nested', 'settings.json');
+    writeFileAtomic(target, '{"a":1}');
+    expect(readFileSync(target, 'utf8')).toBe('{"a":1}');
+    expect(readdirSync(join(dir, 'nested'))).toEqual(['settings.json']);
+  });
+
+  it('replaces an existing file in place', () => {
+    const target = join(dir, 'f.json');
+    writeFileAtomic(target, 'one');
+    writeFileAtomic(target, 'two');
+    expect(readFileSync(target, 'utf8')).toBe('two');
+    expect(readdirSync(dir)).toEqual(['f.json']); // no orphaned tmp
+  });
+});
+
+describe('cacheDir', () => {
+  it('honors XDG_CACHE_HOME (the seam every cache test relies on)', () => {
+    const orig = process.env.XDG_CACHE_HOME;
+    process.env.XDG_CACHE_HOME = join(tmpdir(), 'xdg-test');
+    try {
+      expect(cacheDir()).toBe(join(tmpdir(), 'xdg-test', 'claudinho'));
+    } finally {
+      if (orig === undefined) delete process.env.XDG_CACHE_HOME;
+      else process.env.XDG_CACHE_HOME = orig;
+    }
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.20.0",
+    "@vitest/coverage-v8": "^4.1.9",
     "tsup": "^8.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",

--- a/packages/core/src/i18n.ts
+++ b/packages/core/src/i18n.ts
@@ -1,9 +1,7 @@
 /** Supported UI locales — same set as CLI/MCP `lang`. */
 export type Lang = 'en' | 'es' | 'pt' | 'fr';
 
-type Dict = Record<string, string>;
-
-const EN: Dict = {
+const EN = {
   'bracket.title': 'Knockout bracket',
   'bracket.stageTitle': 'Knockout · {stage}',
   'bracket.shareTitle': 'Knockout bracket · 2026',
@@ -34,6 +32,13 @@ const EN: Dict = {
   'stage.f': 'Final',
   'stage.friendly': 'Friendly',
 };
+
+/**
+ * Every locale must define exactly the EN key set — a missing or mistyped
+ * es/pt/fr key fails `tsc` instead of silently rendering mid-sentence English
+ * at runtime (the fallback in `t()` stays, but only for genuinely unknown keys).
+ */
+type Dict = Record<keyof typeof EN, string>;
 
 const ES: Dict = {
   'bracket.title': 'Cuadro de eliminatorias',
@@ -142,8 +147,10 @@ export function normalizeLang(lang?: string): Lang {
 
 /** Translate a message key with optional `{placeholder}` interpolation. */
 export function t(lang: string | undefined, key: string, vars?: Record<string, string>): string {
-  const dict = CATALOGS[normalizeLang(lang)];
-  let s = dict[key] ?? EN[key] ?? key;
+  // Widen for lookup: callers pass arbitrary string keys (unknown → key echo).
+  const dict: Record<string, string> = CATALOGS[normalizeLang(lang)];
+  const en: Record<string, string> = EN;
+  let s = dict[key] ?? en[key] ?? key;
   if (vars) {
     for (const [k, v] of Object.entries(vars)) s = s.replaceAll(`{${k}}`, v);
   }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -55,7 +55,8 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "smoke:stdio": "node scripts/stdio-smoke.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.21.0",
@@ -64,6 +65,7 @@
   "devDependencies": {
     "@claudinho/core": "workspace:*",
     "@types/node": "^22.20.0",
+    "@vitest/coverage-v8": "^4.1.9",
     "tsup": "^8.0.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.9"

--- a/packages/mcp/scripts/stdio-smoke.mjs
+++ b/packages/mcp/scripts/stdio-smoke.mjs
@@ -15,7 +15,9 @@ import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const pkgDir = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
-const entry = join(pkgDir, 'dist', 'index.js');
+// argv[2] overrides the server entry — used to verify this guard itself trips
+// (e.g. against a wrapper that pollutes stdout before delegating to the dist).
+const entry = process.argv[2] ? resolve(process.argv[2]) : join(pkgDir, 'dist', 'index.js');
 const pkg = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
 
 if (!existsSync(entry)) {
@@ -42,22 +44,42 @@ try {
   out = String(e.stdout ?? ''); // stdin EOF may exit non-zero after the replies were written
 }
 
-const byId = {};
-for (const line of out.split('\n')) {
-  const trimmed = line.trim();
-  if (!trimmed) continue;
-  try {
-    const msg = JSON.parse(trimmed);
-    if (msg.id !== undefined) byId[msg.id] = msg;
-  } catch {
-    /* non-JSON noise on stdout would itself be a protocol bug — caught below by absence */
-  }
-}
-
 const fail = (msg) => {
   console.error(`✗ stdio smoke: ${msg}`);
   process.exit(1);
 };
+
+// stdout of a stdio MCP server must be PURE JSON-RPC — any other line (a boot
+// banner, a stray console.log) breaks strict clients. Logs belong on stderr
+// (the server's "ready" banner correctly goes there). Fail loudly on any
+// non-empty stdout line that isn't a JSON-RPC 2.0 message, instead of
+// swallowing it and passing on the replies that happened to parse.
+const byId = {};
+const garbage = [];
+for (const line of out.split('\n')) {
+  const trimmed = line.trim();
+  if (!trimmed) continue;
+  let msg;
+  try {
+    msg = JSON.parse(trimmed);
+  } catch {
+    garbage.push(trimmed);
+    continue;
+  }
+  if (msg?.jsonrpc !== '2.0') {
+    garbage.push(trimmed);
+    continue;
+  }
+  if (msg.id !== undefined) byId[msg.id] = msg;
+}
+if (garbage.length) {
+  fail(
+    `stdout is not pure JSON-RPC — a stdio MCP server must keep stdout protocol-clean (log to stderr). Offending line(s):\n   ${garbage
+      .slice(0, 5)
+      .map((l) => l.slice(0, 200))
+      .join('\n   ')}`,
+  );
+}
 
 const init = byId[1]?.result;
 if (!init) fail('no initialize response over stdio');

--- a/packages/mcp/scripts/stdio-smoke.mjs
+++ b/packages/mcp/scripts/stdio-smoke.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Real-stdio smoke test for the built MCP server — the transport every install
+ * channel actually uses (Registry/Smithery/Cursor launch `node dist/index.js`
+ * over stdio) but vitest never exercises (it imports handlers in-process).
+ * Spawns the dist, performs the MCP handshake, lists tools (every one must
+ * declare an outputSchema), and calls the offline `get_team` tool end-to-end.
+ * No network. Exits non-zero on any mismatch.
+ *
+ *   pnpm -F @claudinho/mcp smoke:stdio   (CI runs it on Node 22/24 and the Node-20 floor)
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pkgDir = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+const entry = join(pkgDir, 'dist', 'index.js');
+const pkg = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
+
+if (!existsSync(entry)) {
+  console.error('✗ dist/index.js not found — run `pnpm -F @claudinho/mcp build` first.');
+  process.exit(1);
+}
+
+const req = (id, method, params) =>
+  `${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`;
+const input =
+  req(1, 'initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'stdio-smoke', version: '1' },
+  }) +
+  `${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n` +
+  req(2, 'tools/list', {}) +
+  req(3, 'tools/call', { name: 'get_team', arguments: { query: 'mexico' } });
+
+let out = '';
+try {
+  out = execFileSync(process.execPath, [entry], { input, encoding: 'utf8', timeout: 30_000 });
+} catch (e) {
+  out = String(e.stdout ?? ''); // stdin EOF may exit non-zero after the replies were written
+}
+
+const byId = {};
+for (const line of out.split('\n')) {
+  const trimmed = line.trim();
+  if (!trimmed) continue;
+  try {
+    const msg = JSON.parse(trimmed);
+    if (msg.id !== undefined) byId[msg.id] = msg;
+  } catch {
+    /* non-JSON noise on stdout would itself be a protocol bug — caught below by absence */
+  }
+}
+
+const fail = (msg) => {
+  console.error(`✗ stdio smoke: ${msg}`);
+  process.exit(1);
+};
+
+const init = byId[1]?.result;
+if (!init) fail('no initialize response over stdio');
+if (init.serverInfo?.name !== 'claudinho')
+  fail(`serverInfo.name is ${JSON.stringify(init.serverInfo?.name)}, expected "claudinho"`);
+if (init.serverInfo?.version !== pkg.version)
+  fail(
+    `server reports v${init.serverInfo?.version} but package.json says v${pkg.version} — stale dist? rebuild`,
+  );
+
+const tools = byId[2]?.result?.tools ?? [];
+if (tools.length < 9) fail(`expected >= 9 tools over stdio, got ${tools.length}`);
+const missingSchema = tools.filter((t) => !t.outputSchema).map((t) => t.name);
+if (missingSchema.length) fail(`tools missing outputSchema: ${missingSchema.join(', ')}`);
+
+const call = byId[3]?.result;
+if (!call)
+  fail(
+    `get_team call returned no result${byId[3]?.error ? `: ${JSON.stringify(byId[3].error)}` : ''}`,
+  );
+if (call.isError) fail(`get_team returned isError: ${JSON.stringify(call.content)}`);
+const team = call.structuredContent?.team;
+if (team?.code !== 'MEX')
+  fail(`get_team("mexico") resolved ${JSON.stringify(team)} — expected code "MEX"`);
+
+console.log(
+  `✓ stdio smoke: ${init.serverInfo.name}@${init.serverInfo.version} · ${tools.length} tools, all with outputSchema · get_team("mexico") → MEX (node ${process.version})`,
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@types/node':
         specifier: ^22.20.0
         version: 22.20.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.9
+        version: 4.1.9(vitest@4.1.9)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
@@ -43,13 +46,16 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@22.20.0)(vite@6.4.3(@types/node@22.20.0)(tsx@4.22.4))
+        version: 4.1.9(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(vite@6.4.3(@types/node@22.20.0)(tsx@4.22.4))
 
   packages/core:
     devDependencies:
       '@types/node':
         specifier: ^22.20.0
         version: 22.20.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.9
+        version: 4.1.9(vitest@4.1.9)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
@@ -61,7 +67,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@22.20.0)(vite@6.4.3(@types/node@22.20.0)(tsx@4.22.4))
+        version: 4.1.9(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(vite@6.4.3(@types/node@22.20.0)(tsx@4.22.4))
 
   packages/mcp:
     dependencies:
@@ -78,6 +84,9 @@ importers:
       '@types/node':
         specifier: ^22.20.0
         version: 22.20.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.9
+        version: 4.1.9(vitest@4.1.9)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
@@ -86,9 +95,30 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@22.20.0)(vite@6.4.3(@types/node@22.20.0)(tsx@4.22.4))
+        version: 4.1.9(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(vite@6.4.3(@types/node@22.20.0)(tsx@4.22.4))
 
 packages:
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.5.1':
     resolution: {integrity: sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==}
@@ -627,6 +657,15 @@ packages:
   '@types/node@22.20.0':
     resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
 
+  '@vitest/coverage-v8@4.1.9':
+    resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.9
+      vitest: 4.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
@@ -686,6 +725,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -900,6 +942,10 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -911,6 +957,9 @@ packages:
   hono@4.12.25:
     resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -941,12 +990,27 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -967,6 +1031,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1124,6 +1195,11 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -1192,6 +1268,10 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -1379,6 +1459,21 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.5.1':
     optionalDependencies:
@@ -1701,6 +1796,20 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.9
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(vite@6.4.3(@types/node@22.20.0)(tsx@4.22.4))
+
   '@vitest/expect@4.1.9':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1765,6 +1874,12 @@ snapshots:
   any-promise@1.3.0: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   body-parser@2.2.2:
     dependencies:
@@ -2007,6 +2122,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.4:
@@ -2014,6 +2131,8 @@ snapshots:
       function-bind: 1.1.2
 
   hono@4.12.25: {}
+
+  html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -2039,9 +2158,24 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jose@6.2.3: {}
 
   joycon@3.1.1: {}
+
+  js-tokens@10.0.0: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -2056,6 +2190,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   math-intrinsics@1.1.0: {}
 
@@ -2235,6 +2379,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  semver@7.8.5: {}
+
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -2328,6 +2474,10 @@ snapshots:
       tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -2418,7 +2568,7 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.22.4
 
-  vitest@4.1.9(@types/node@22.20.0)(vite@6.4.3(@types/node@22.20.0)(tsx@4.22.4)):
+  vitest@4.1.9(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(vite@6.4.3(@types/node@22.20.0)(tsx@4.22.4)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@6.4.3(@types/node@22.20.0)(tsx@4.22.4))
@@ -2442,6 +2592,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.0
+      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
     transitivePeerDependencies:
       - msw
 

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Tarball-contents guard. `npm pack --dry-run` each publishable package and
+ * assert nothing ships beyond dist/ + README.md + LICENSE + package.json —
+ * and never a .mcpb bundle, anything under docs/, or a dotfile. Also asserts
+ * git tracks nothing under docs/ (the 0.8.3 `!docs/PRD.md` gitignore-exception
+ * leak class). CI runs this after build; run locally from the repo root:
+ *
+ *   node scripts/check-pack.mjs
+ */
+import { execFileSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+const PKGS = ['core', 'cli', 'mcp'];
+const ALLOWED = /^(dist\/|README\.md$|LICENSE$|package\.json$)/;
+const FORBIDDEN = /^docs\/|\.mcpb$|(^|\/)\./; // docs/, .mcpb anywhere, any dotfile/dotdir
+
+let failed = false;
+
+for (const p of PKGS) {
+  const dir = join(root, 'packages', p);
+  const json = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: dir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const [info] = JSON.parse(json);
+  const files = info.files.map((f) => f.path);
+  const bad = files.filter((f) => !ALLOWED.test(f) || FORBIDDEN.test(f));
+  if (bad.length) {
+    failed = true;
+    console.error(`✗ @claudinho/${p} would ship unexpected files:\n   ${bad.join('\n   ')}`);
+  } else {
+    console.log(
+      `✓ @claudinho/${p}: ${files.length} files, all expected (${(info.size / 1024).toFixed(0)} KB)`,
+    );
+  }
+}
+
+const tracked = execFileSync('git', ['ls-files', 'docs'], { cwd: root, encoding: 'utf8' }).trim();
+if (tracked) {
+  failed = true;
+  console.error(
+    `✗ git tracks files under docs/ — the private boundary is breached (check .gitignore for a "!docs/" exception):\n   ${tracked.split('\n').join('\n   ')}`,
+  );
+} else {
+  console.log('✓ docs/ is untracked (private boundary holds)');
+}
+
+process.exit(failed ? 1 : 0);

--- a/scripts/release-qa.sh
+++ b/scripts/release-qa.sh
@@ -215,6 +215,56 @@ else
   SKIP=$((SKIP+1))
 fi
 
+# T8 — bundle↔live drift: every fixture ESPN serves in a ±1-day window must exist
+# in the bundled schedule under the SAME id, with a kickoff within 12h. The live
+# overlay is id-keyed, so an ESPN renumber/reschedule silently divorces static
+# from live (missed overlays, stale kickoff/venue) with no crash — regenerate the
+# schedule if this trips. SKIPs when the feed is unreachable/empty (a network
+# blip must never block a release) or under a non-default competition (the
+# bundle is fifa.world only).
+if [ -n "${CLI:-}" ]; then
+  printf '  \033[33m⚠ SKIP\033[0m  bundle↔live drift check (CLI override tests a global install; tripwire imports the local core)\n'
+  SKIP=$((SKIP+1))
+elif [ "$CLAUDINHO_COMPETITION" != "fifa.world" ]; then
+  printf '  \033[33m⚠ SKIP\033[0m  bundle↔live drift check (non-default competition — the bundled schedule is fifa.world)\n'
+  SKIP=$((SKIP+1))
+elif [ -f "$CORE_DIST" ]; then
+  DRIFT="$(node --input-type=module -e "
+import { allFixtures, makeAdapter } from 'file://$CORE_DIST';
+const bundled = new Map(allFixtures().map((f) => [f.id, f]));
+const adapter = makeAdapter('espn');
+const day = (d) => d.toISOString().slice(0, 10);
+const now = Date.now();
+try {
+  const served = [];
+  for (const off of [-1, 0, 1]) {
+    served.push(...(await adapter.fetchByDate(day(new Date(now + off * 864e5)))));
+  }
+  if (!served.length) { process.stdout.write('DRIFT-SKIP'); process.exit(0); }
+  const missing = served.filter((m) => !bundled.has(m.id)).map((m) => 'missing:' + m.id);
+  const shifted = served.filter((m) => {
+    const b = bundled.get(m.id);
+    return b && Math.abs(Date.parse(b.kickoff) - Date.parse(m.kickoff)) > 12 * 3600e3;
+  }).map((m) => 'shifted:' + m.id);
+  process.stdout.write(missing.length || shifted.length
+    ? 'DRIFT-FAIL ' + [...missing, ...shifted].join(',')
+    : 'DRIFT-OK ' + served.length);
+} catch { process.stdout.write('DRIFT-SKIP'); }
+" 2>/dev/null)"
+  case "$DRIFT" in
+    DRIFT-OK*)
+      check ok "bundle↔live: every live-served fixture id is in the bundle, kickoff within 12h (${DRIFT#DRIFT-OK } fixtures)" ;;
+    DRIFT-FAIL*)
+      check no "bundle↔live drift: ${DRIFT#DRIFT-FAIL } — regenerate the schedule (pnpm -F @claudinho/core gen:schedule)" ;;
+    *)
+      printf '  \033[33m⚠ SKIP\033[0m  bundle↔live drift check (feed unreachable/empty)\n'
+      SKIP=$((SKIP+1)) ;;
+  esac
+else
+  printf '  \033[33m⚠ SKIP\033[0m  bundle↔live drift check (core dist not built — run pnpm -r build)\n'
+  SKIP=$((SKIP+1))
+fi
+
 echo
 bold "tripwires: $PASS passed · $FAIL failed · $SKIP skipped"
 echo "NOTE: this covers CLI/share rendering. MCP arg-threading (tz/lang on get_bracket"

--- a/scripts/smoke-statusline.mjs
+++ b/scripts/smoke-statusline.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform statusline smoke: seed a fresh micro-cache, run the built
+ * `claudinho prompt`, and assert it renders the seeded live match. Plain node
+ * (no shell quoting) so the same command works on the Windows/macOS CI legs.
+ * Timing is printed for visibility but not asserted here — the hard bound lives
+ * in packages/cli/test/hotpath-latency.test.ts.
+ *
+ *   pnpm -r build && node scripts/smoke-statusline.mjs
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+const dist = join(root, 'packages', 'cli', 'dist', 'index.js');
+if (!existsSync(dist)) {
+  console.error('✗ packages/cli/dist not found — run `pnpm -r build` first.');
+  process.exit(1);
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'claudinho-smoke-'));
+try {
+  const cacheDir = join(dir, 'claudinho');
+  mkdirSync(cacheDir, { recursive: true });
+  const now = new Date().toISOString();
+  // Fresh on BOTH cadences (live + fixtures) so the hot path spawns no refresher
+  // and touches no network — this smoke must pass on an offline runner.
+  writeFileSync(
+    join(cacheDir, 'state.json'),
+    JSON.stringify({
+      updatedAt: now,
+      degraded: false,
+      source: 'espn',
+      competition: 'fifa.world',
+      live: [
+        {
+          id: 'smoke1',
+          stage: 'GROUP',
+          group: 'A',
+          kickoff: now,
+          venue: 'Estadio Banorte',
+          home: { code: 'MEX', name: 'Mexico', flag: '🇲🇽' },
+          away: { code: 'ECU', name: 'Ecuador', flag: '🇪🇨' },
+          status: 'LIVE',
+          minute: 30,
+          score: { home: 1, away: 0 },
+          updatedAt: now,
+        },
+      ],
+      fixtures: [],
+      fixturesUpdatedAt: now,
+    }),
+  );
+
+  const env = { ...process.env, XDG_CACHE_HOME: dir, CLAUDINHO_FLAGS: 'on' };
+  delete env.CLAUDINHO_TEAM;
+  delete env.CLAUDINHO_COMPETITION;
+
+  const t0 = performance.now();
+  const out = execFileSync(process.execPath, [dist, 'prompt'], {
+    env,
+    encoding: 'utf8',
+    input: '', // immediate stdin EOF — the Cursor-payload drain must not block
+    timeout: 15_000,
+  });
+  const ms = performance.now() - t0;
+
+  if (!out.includes('🇲🇽') && !out.includes('MEX')) {
+    console.error(`✗ statusline did not render the seeded match. Output: ${JSON.stringify(out)}`);
+    process.exit(1);
+  }
+  console.log(`✓ statusline smoke (${ms.toFixed(0)}ms): ${out.trim()}`);
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What

Batch 3 of the F5 technical review (`docs/F5_TECHNICAL_IMPLEMENTATION_PLAN.md`): the CI & guard-hardening layer. **No release needed** — test/CI surface plus two behavior-identical product touches that ride the next tag (v0.9.0).

### New executable guards
- **MCP stdio smoke** (`packages/mcp/scripts/stdio-smoke.mjs`, TEST-1): spawns the built dist over real stdio — initialize handshake (server version must match package.json, catching stale dists), `tools/list` (≥9 tools, every one with an `outputSchema`), and an offline `get_team` call end-to-end. Runs on Node 22/24 **and the Node-20 engines floor** (plain `node`, since pnpm needs ≥22.13).
- **Windows + macOS CI legs** (ARCH-4b/TEST-2): first-ever execution on the platforms the README claims — full build + test suite + offline CLI smoke + seeded-cache statusline smoke (`scripts/smoke-statusline.mjs`, cross-platform plain-node, no shell quoting) + stdio smoke. `fail-fast: false` so both report.
- **Hot-path latency budget** (`packages/cli/test/hotpath-latency.test.ts`, TEST-3): median-of-10 runs of the built `prompt` with a fresh seeded cache under a loose order-of-magnitude bound (500ms; 1500ms on win32 — catches a heavy import sneaking onto the hot path, doesn't try to certify 150ms on shared runners), plus an in-process contract: `cmdPrompt`/`cmdHook` with a fresh cache make **zero fetches and spawn zero refreshers**.
- **Pack-contents guard** (`scripts/check-pack.mjs`, TEST-7): `npm pack --dry-run` per package — only dist/README/LICENSE/package.json, never a `.mcpb` or `docs/`; plus `git ls-files docs/` must be empty (the 0.8.3 `!docs/PRD.md` leak class).
- **release-qa T8** (TEST-6): bundle↔live drift tripwire — every fixture ESPN serves in a ±1-day window must exist in the bundled schedule under the same id with kickoff within 12h (the overlay merge is id-keyed, so a silent ESPN renumber divorces static from live). SKIPs on degraded feed / non-default competition / `CLI=` override.
- **i18n key parity** (TEST-5): both catalogs now typed `Record<keyof typeof EN, string>` — a missing or mistyped es/pt/fr key fails `tsc` instead of shipping mid-sentence English. Compile-time only, zero runtime change.
- **Coverage visibility** (TEST-8): non-gating CI job publishes per-package V8 coverage summaries (today: core 82.7% / mcp 87.2% / cli 88.3% statements).

### Hardening
- **SHA-pinned every workflow action** (SEC-4) — `publish.yml` holds the npm OIDC credential for all three packages; a re-pointed action tag must not execute there. Dependabot maintains SHA pins.
- **Atomic `~/.claude` settings writes** (SEC-5): `install.ts` now writes tmp+rename via a new shared `packages/cli/src/paths.ts`, which also unifies the triplicated `cacheDir` (ARCH-11); `cache.ts`/`marketCache.ts`/`starNudge.ts` all read from the one helper. Behavior-identical (deliberately **no** `%LOCALAPPDATA%` switch yet — that would move existing Windows users' caches; revisit after the Windows leg is green).

## Verified
- Full gate green locally: build · typecheck · **627 tests** (244/118/265) · Biome.
- `pnpm release:qa` against the live feed: **8/8 tripwires** incl. T8 (9 live fixtures matched to the bundle).
- stdio smoke: `claudinho@0.8.19 · 9 tools, all with outputSchema · get_team("mexico") → MEX`.
- statusline smoke: 55ms seeded render.
- Coverage flag pass-through verified (`--` separator silently drops the flags — the CI step avoids it, with a comment).

## Notes for review
- The Windows leg is expected to be the risky job — it has never run before. If it surfaces real breakage beyond smoke fixes, I'll triage into a follow-up rather than bloat this PR.
- `pnpm-lock.yaml` delta = `@vitest/coverage-v8` (dev-only, ^4.1.9 matching vitest).

Findings addressed: TEST-1/2/3/5/6/7/8 · SEC-4/5 · ARCH-4b/11 from `docs/F5_TECHNICAL_REVIEW.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code (Fable 5) <noreply@anthropic.com>