### PR TITLE
chore(seo): lead npm descriptions with the "World Cup MCP server" query

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@claudinho/cli",
   "version": "0.9.0",
-  "description": "Live scores, fixtures, group tables, and read-only prediction-market signals for the 2026 men's football tournament — in your terminal, Claude Code, and Cursor CLI statusline. No API keys. Not affiliated with FIFA or Anthropic.",
+  "description": "Live 2026 World Cup scores, fixtures, group tables, and read-only prediction-market signals in your terminal, Claude Code, and Cursor CLI statusline. No API keys. Not affiliated with FIFA or Anthropic.",
   "type": "module",
   "license": "MIT",
   "author": "Arturo Garrido",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -2,7 +2,7 @@
   "name": "@claudinho/mcp",
   "version": "0.9.0",
   "mcpName": "io.github.arturogarrido/claudinho",
-  "description": "MCP server for the 2026 men's football tournament — live scores, fixtures, standings, read-only prediction-market signals, and paste-ready match cards. Works with Claude Code, Cursor, Codex, Windsurf, Zed. Not affiliated with FIFA or Anthropic.",
+  "description": "World Cup MCP server for the 2026 men's football tournament — live scores, fixtures, standings, read-only prediction-market signals, and paste-ready match cards. Works with Claude Code, Cursor, Codex, Windsurf, Zed. Not affiliated with FIFA or Anthropic.",
   "type": "module",
   "license": "MIT",
   "author": "Arturo Garrido",


### PR DESCRIPTION
## What

Get the money-query tokens into the two discoverable packages' npm descriptions. Search (npm / Google / MCP-directory) weights the short description text heavily and rewards having the exact query tokens adjacent; today we split or omit them and lose "World Cup MCP server" to lesser competitors.

- **`@claudinho/mcp`**: lead with the exact phrase **"World Cup MCP server"** (was "MCP server for the 2026 men's football tournament" — had "MCP server" but not "World Cup").
- **`@claudinho/cli`**: surface **"2026 World Cup"** in the opening (was "for the 2026 men's football tournament").

Descriptive text only, no marks/logos, disclaimer intact (Hard Constraint holds).

## Notes

- **npm re-indexes descriptions only on publish**, so these ride the next release — no version bump in this PR.
- The **GitHub repo description** was updated live (`gh repo edit`) alongside this: now `⚽ 2026 World Cup live scores in your terminal — MCP server, CLI & statusline for Claude Code and Cursor…`.
- **Not MCP-affecting**: no tool shape/description/annotation change, `server.json` and the MCP server INSTRUCTIONS are untouched → no Registry republish.
- Keywords already carry `mcp-server` + `world-cup` as tokens; the win here is description adjacency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>