### PR TITLE
feat: add a privacy policy + Desktop-Extension manifest hygiene (directory submission BLOCKED on API-ownership policy)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -53,11 +53,23 @@ stay on your device, are never uploaded, and you can delete them at any time. (C
 own settings and hook configuration live separately under `~/.claude/`; that is editor
 configuration, not a Claudinho data store.)
 
+## Configuration changes (`init`)
+
+The optional setup commands (`claudinho init claude` / `init cursor`, and the granular
+`init-…` commands) modify your editor's own configuration on your machine so the statusline
+and hook can run: they read your Claude Code (`~/.claude/settings.json`) or Cursor CLI
+(`~/.cursor/cli-config.json`) settings file, add Claudinho's entries, and write it back.
+Before the first change, Claudinho saves a one-time backup of the original alongside it (e.g.
+`settings.json.claudinho.bak`) so you can restore it. This all stays on your machine —
+Claudinho does not read these files for personal data, upload them, or transmit their
+contents anywhere.
+
 ## Data sharing and retention
 
 Claudinho does not sell, rent, share, or transmit your data to anyone, because it collects
-none. It retains nothing on any server (there is no server). The only retained data is the
-local cache described above, which lives on your device under your control.
+none. It retains nothing on any server (there is no server). The only data it retains is
+local and on your own device: the cache described above and, if you ran a setup command, the
+one-time settings backup — both under your control and deletable at any time.
 
 ## Children's privacy
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,74 @@
+# Privacy Policy
+
+**Effective date:** 2026-07-09
+
+Claudinho is an independent, open-source project — a CLI, a Claude Code / Cursor
+statusline, a score-aware hook, and an MCP server (Claude Desktop Extension) that shows
+live football scores in your terminal and coding agent. This policy explains what data
+Claudinho does and does not handle. It applies to the `@claudinho/cli`, `@claudinho/mcp`,
+and `@claudinho/core` packages and the Claude Desktop Extension (`.mcpb`) bundle.
+
+## Short version
+
+Claudinho collects **no personal data**. No accounts, no sign-up, no telemetry, no
+analytics, no tracking, no advertising identifiers. **There is no Claudinho server** —
+nothing you do is sent to us, because there is nothing on our side to send it to.
+
+## What Claudinho does not collect
+
+- No personal information (name, email, location, device identifiers).
+- No usage analytics or telemetry of any kind.
+- No API keys, credentials, or account data (Claudinho requires none).
+- No prompts, code, or conversation content from Claude Code, Cursor, or any MCP client.
+
+## Data Claudinho does handle
+
+To show live results, Claudinho makes outbound HTTPS requests to public, third-party
+sports-data services:
+
+- **ESPN** public scoreboard and standings endpoints — live scores, fixtures, and group tables.
+- **Polymarket** public Gamma API — read-only, informational-only prediction-market signals.
+  Fetched only when market signals are enabled (`CLAUDINHO_MARKETS` is not `off`), and never
+  shown on the statusline or hook.
+
+These requests carry **no personal data and no authentication** — they are anonymous reads
+of public endpoints (a date and competition for scores; a public event slug for market data).
+Claudinho sends these services nothing about you. Your use of those third-party services is
+governed by their own privacy policies:
+
+- ESPN (a division of The Walt Disney Company): <https://privacy.thewaltdisneycompany.com/en/current-privacy-policy/>
+- Polymarket: <https://polymarket.com/>
+
+## Local storage
+
+To keep the statusline fast (it must render in well under 150 ms and never block on the
+network), Claudinho writes a small **cache file on your own machine**, under your home
+directory (e.g. `~/.claude/`). It contains only public match data (scores, fixtures,
+standings) and Claudinho's own settings — never personal data. It stays on your device, is
+never uploaded, and you can delete it at any time.
+
+## Data sharing and retention
+
+Claudinho does not sell, rent, share, or transmit your data to anyone, because it collects
+none. It retains nothing on any server (there is no server). The only retained data is the
+local cache described above, which lives on your device under your control.
+
+## Children's privacy
+
+Claudinho is a general-audience developer tool, not directed at children, and collects no
+personal data from anyone.
+
+## Changes to this policy
+
+If this policy changes, the updated version is published in this file in the public
+repository with a new effective date.
+
+## Contact
+
+Questions or concerns: open an issue at <https://github.com/arturogarrido/claudinho/issues>.
+
+---
+
+Claudinho is an independent, open-source fan project. **Not affiliated with, endorsed by, or
+connected to FIFA or Anthropic.** Prediction-market data is read-only and informational only,
+not betting or trading advice.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -31,21 +31,27 @@ sports-data services:
   Fetched only when market signals are enabled (`CLAUDINHO_MARKETS` is not `off`), and never
   shown on the statusline or hook.
 
-These requests carry **no personal data and no authentication** — they are anonymous reads
-of public endpoints (a date and competition for scores; a public event slug for market data).
-Claudinho sends these services nothing about you. Your use of those third-party services is
-governed by their own privacy policies:
+Claudinho itself adds **no accounts, authentication, profile, or prompt data** to these
+requests — they are anonymous reads of public endpoints (a date and competition for scores;
+a public event slug for market data). As with any HTTP request, though, the service you
+connect to still receives the standard request metadata your device sends, such as your **IP
+address and HTTP headers**; Claudinho cannot avoid this and adds nothing beyond it. Your use
+of those third-party services is governed by their own privacy policies:
 
 - ESPN (a division of The Walt Disney Company): <https://privacy.thewaltdisneycompany.com/en/current-privacy-policy/>
-- Polymarket: <https://polymarket.com/>
+- Polymarket: <https://polymarket.com/privacy>
 
 ## Local storage
 
 To keep the statusline fast (it must render in well under 150 ms and never block on the
-network), Claudinho writes a small **cache file on your own machine**, under your home
-directory (e.g. `~/.claude/`). It contains only public match data (scores, fixtures,
-standings) and Claudinho's own settings — never personal data. It stays on your device, is
-never uploaded, and you can delete it at any time.
+network), Claudinho writes a small **cache on your own machine**, in your cache directory
+(`$XDG_CACHE_HOME/claudinho`, falling back to `~/.cache/claudinho`). These files hold only
+public match data and Claudinho's own local counters — for example `state.json` (cached
+scores, fixtures, and standings), `market-signals.json` (cached market reads), and
+`runs.json` (a local counter for the star-reminder nudge). They contain no personal data,
+stay on your device, are never uploaded, and you can delete them at any time. (Claude Code's
+own settings and hook configuration live separately under `~/.claude/`; that is editor
+configuration, not a Claudinho data store.)
 
 ## Data sharing and retention
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -43,15 +43,20 @@ of those third-party services is governed by their own privacy policies:
 
 ## Local storage
 
-To keep the statusline fast (it must render in well under 150 ms and never block on the
-network), Claudinho writes a small **cache on your own machine**, in your cache directory
-(`$XDG_CACHE_HOME/claudinho`, falling back to `~/.cache/claudinho`). These files hold only
-public match data and Claudinho's own local counters — for example `state.json` (cached
-scores, fixtures, and standings), `market-signals.json` (cached market reads), and
-`runs.json` (a local counter for the star-reminder nudge). They contain no personal data,
-stay on your device, are never uploaded, and you can delete them at any time. (Claude Code's
-own settings and hook configuration live separately under `~/.claude/`; that is editor
-configuration, not a Claudinho data store.)
+The behavior differs by component:
+
+- The **CLI and statusline** keep a small **cache on your own machine** so the statusline
+  renders fast (well under 150 ms, never blocking on the network). It lives in your cache
+  directory (`$XDG_CACHE_HOME/claudinho`, falling back to `~/.cache/claudinho`) and holds only
+  public match data and Claudinho's own local counters — for example `state.json` (cached
+  live/upcoming scores and fixtures), `market-signals.json` (cached market reads), and
+  `runs.json` (a local counter for the star-reminder nudge). These files contain no personal
+  data, stay on your device, are never uploaded, and you can delete them at any time.
+- The **MCP server** keeps its cache **in memory only** — a short-lived in-process cache for
+  the life of the running server — and writes **no cache files to disk**.
+
+(Claude Code's own settings and hook configuration live separately under `~/.claude/`; that is
+editor configuration, not a Claudinho data store — see below.)
 
 ## Configuration changes (`init`)
 
@@ -66,8 +71,10 @@ contents anywhere.
 
 ## Data sharing and retention
 
-Claudinho does not sell, rent, share, or transmit your data to anyone, because it collects
-none. It retains nothing on any server (there is no server). The only data it retains is
+Claudinho does not sell or share your data, and does not transmit any **user-supplied** data.
+Its only third-party disclosures are the provider request parameters and the transport
+metadata (such as IP address and HTTP headers) described above, inherent to any HTTP request.
+It retains nothing on any server (there is no server). The only data it retains is
 local and on your own device: the cache described above and, if you ran a setup command, the
 one-time settings backup — both under your control and deletable at any time.
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ Claudinho is a solo, $0, organic fan project — a GitHub star is the only signa
 
 New here? [`CONTRIBUTING.md`](CONTRIBUTING.md) has the layout, the dev loop, and good first issues.
 
+## Privacy
+
+Claudinho collects **no personal data** — no accounts, no telemetry, no analytics, no tracking. There is no Claudinho server. To show live results it makes anonymous, read-only requests to public sports-data services (ESPN for scores/standings; Polymarket for informational-only market signals), sending them nothing about you, and keeps a small cache on your own machine. Full details: **[PRIVACY.md](PRIVACY.md)**.
+
 ## License
 
 MIT © 2026 Arturo Garrido. All three packages publish with npm provenance via OIDC trusted publishing.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ New here? [`CONTRIBUTING.md`](CONTRIBUTING.md) has the layout, the dev loop, and
 
 ## Privacy
 
-Claudinho collects **no personal data** — no accounts, no telemetry, no analytics, no tracking. There is no Claudinho server. To show live results it makes anonymous, read-only requests to public sports-data services (ESPN for scores/standings; Polymarket for informational-only market signals), sending them nothing about you, and keeps a small cache on your own machine. Full details: **[PRIVACY.md](PRIVACY.md)**.
+Claudinho collects **no personal data** — no accounts, no telemetry, no analytics, no tracking. There is no Claudinho server. To show live results it makes read-only requests to public sports-data services (ESPN for scores/standings; Polymarket for informational-only market signals) with no account or personal data attached, and keeps a small cache in your local cache directory (`~/.cache/claudinho`). Full details: **[PRIVACY.md](PRIVACY.md)**.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Claudinho is a solo, $0, organic fan project — a GitHub star is the only signa
 
 New here? [`CONTRIBUTING.md`](CONTRIBUTING.md) has the layout, the dev loop, and good first issues.
 
-## Privacy
+## Privacy Policy
 
 Claudinho collects **no personal data** — no accounts, no telemetry, no analytics, no tracking. There is no Claudinho server. To show live results it makes read-only requests to public sports-data services (ESPN for scores/standings; Polymarket for informational-only market signals) with no account or personal data attached, and keeps a small cache in your local cache directory (`~/.cache/claudinho`). Full details: **[PRIVACY.md](PRIVACY.md)**.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -87,12 +87,14 @@ live scores from **ESPN's** public scoreboard (swappable provider, attributed in
 output), market signals from Polymarket. Stdout carries only the MCP protocol;
 diagnostics go to stderr.
 
-## Privacy
+## Privacy Policy
 
 No personal data collected — no accounts, no telemetry, no analytics, no tracking, and no
-Claudinho server. Live scores come from anonymous, read-only requests to public services
-(ESPN; Polymarket for informational-only market signals); a small cache lives on your own
-machine. Full policy: [PRIVACY.md](https://github.com/arturogarrido/claudinho/blob/main/PRIVACY.md).
+Claudinho server. To show live scores, Claudinho makes read-only requests to public services
+(ESPN; Polymarket for informational-only market signals) with no account or personal data
+attached, though those services still receive standard request metadata (such as your IP
+address) like any HTTP call. A small cache sits in your local cache directory
+(`~/.cache/claudinho`). Full policy: [PRIVACY.md](https://github.com/arturogarrido/claudinho/blob/main/PRIVACY.md).
 
 ## License
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -87,6 +87,13 @@ live scores from **ESPN's** public scoreboard (swappable provider, attributed in
 output), market signals from Polymarket. Stdout carries only the MCP protocol;
 diagnostics go to stderr.
 
+## Privacy
+
+No personal data collected — no accounts, no telemetry, no analytics, no tracking, and no
+Claudinho server. Live scores come from anonymous, read-only requests to public services
+(ESPN; Polymarket for informational-only market signals); a small cache lives on your own
+machine. Full policy: [PRIVACY.md](https://github.com/arturogarrido/claudinho/blob/main/PRIVACY.md).
+
 ## License
 
 MIT © 2026 Arturo Garrido · [source & issues](https://github.com/arturogarrido/claudinho)

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -93,8 +93,8 @@ No personal data collected — no accounts, no telemetry, no analytics, no track
 Claudinho server. To show live scores, Claudinho makes read-only requests to public services
 (ESPN; Polymarket for informational-only market signals) with no account or personal data
 attached, though those services still receive standard request metadata (such as your IP
-address) like any HTTP call. A small cache sits in your local cache directory
-(`~/.cache/claudinho`). Full policy: [PRIVACY.md](https://github.com/arturogarrido/claudinho/blob/main/PRIVACY.md).
+address) like any HTTP call. The MCP server keeps its cache **in memory only** and writes
+nothing to disk. Full policy: [PRIVACY.md](https://github.com/arturogarrido/claudinho/blob/main/PRIVACY.md).
 
 ## License
 

--- a/packages/mcp/mcpb/manifest.json
+++ b/packages/mcp/mcpb/manifest.json
@@ -13,6 +13,7 @@
   "documentation": "https://github.com/arturogarrido/claudinho#readme",
   "support": "https://github.com/arturogarrido/claudinho/issues",
   "license": "MIT",
+  "privacy_policies": ["https://github.com/arturogarrido/claudinho/blob/main/PRIVACY.md"],
   "keywords": ["football", "soccer", "world-cup", "2026", "live-scores"],
   "server": {
     "type": "node",

--- a/packages/mcp/test/manifest.test.ts
+++ b/packages/mcp/test/manifest.test.ts
@@ -11,6 +11,7 @@ const read = (rel: string) =>
   JSON.parse(readFileSync(new URL(rel, import.meta.url), 'utf8')) as {
     version: string;
     tools?: { name: string }[];
+    privacy_policies?: unknown;
   };
 
 describe('mcpb manifest', () => {
@@ -19,6 +20,19 @@ describe('mcpb manifest', () => {
   it('version matches package.json', () => {
     const pkg = read('../package.json');
     expect(manifest.version).toBe(pkg.version);
+  });
+
+  it('declares an https privacy policy (required for the Claude Desktop Extensions directory)', () => {
+    // The extension makes outbound calls (ESPN/Polymarket), so Anthropic's directory
+    // requires a privacy_policies array of HTTPS URLs. Guard it so a manifest edit
+    // can't silently drop the field and fail review.
+    const policies = manifest.privacy_policies;
+    expect(Array.isArray(policies)).toBe(true);
+    expect((policies as string[]).length).toBeGreaterThan(0);
+    for (const url of policies as string[]) {
+      expect(typeof url).toBe('string');
+      expect(url).toMatch(/^https:\/\//);
+    }
   });
 
   it('lists exactly the tools the server exposes', async () => {


### PR DESCRIPTION
## What this is (reframed after review)

Adds a **privacy policy** and Desktop-Extension **manifest hygiene** to the repo. It began as prep to submit the `.mcpb` to Anthropic's Claude Desktop Extensions directory — but review surfaced a **policy blocker that no privacy-doc change can fix** (see below), so this PR is now scoped as **general privacy/hygiene that stands on its own**, and the submission is **off the table**.

## ⚠️ Blocker — Anthropic API-ownership policy (do NOT submit)

Anthropic's directory requires first-party API ownership:

- **Software Directory Policy §3.F:** "Developers must verify that they own or control any API endpoint, domain, or user interface their Software connects to, as well as any external resources it retrieves or renders."
- **Review checklist → API ownership:** "Your server must call your own first-party APIs, or APIs you legitimately proxy. The MCP server domain should match your service."

Claudinho calls **ESPN** (`packages/core/src/adapters/espn.ts`) and **Polymarket** (`packages/core/src/markets/polymarket.ts`) directly — third-party public APIs it neither owns nor proxies. There is no local-extension carve-out, so **the bundle is ineligible.**

There is no quick unlock. Even the planned first-party `services/gateway` (Claudinho's own domain reading the feeds server-side) is **necessary but not sufficient** — "legitimately proxy" still requires the *right* to serve ESPN/Polymarket data (provider authorization) or a written Anthropic exception. Realistically the directory is not attainable for a free, third-party-data fan project without one of those, so submission is off the table.

## What still lands here (good hygiene regardless of the directory)

- **`PRIVACY.md`** (new): honest zero-data policy. Distinguishes the **CLI/statusline** disk cache (`~/.cache/claudinho`: `state.json` live/upcoming scores + fixtures, `market-signals.json`, `runs.json`) from the **MCP server**, which caches in-memory only and writes nothing to disk. Discloses the read-only ESPN/Polymarket calls (and the transport metadata like IP/headers they inherently receive), and the `init` config-rewrite + one-time `.claudinho.bak` backup. Dual disclaimer + market caveat intact.
- **README + mcp README**: a **"Privacy Policy"** section (the exact heading the checklist wants).
- **`manifest.json`**: `privacy_policies` array (valid metadata pointing at the policy) + a `manifest.test.ts` guard.

## Verified

- Full gate green; mcp tests 119; `.mcpb` rebuilt and inspected (manifest_version 0.3, `privacy_policies` present, all 9 tools carry `title` + `readOnlyHint`).
- Three review rounds addressed: network-metadata claim, cache path/contents (vs `paths.ts`/`cache.ts`), CLI-vs-MCP storage split (MCP is in-process `Map`, tools.ts), Polymarket link → `https://polymarket.com/privacy`, `init` config/backup disclosure, sharing-vs-disclosure wording, exact heading.

## Recommendation

Merge as **privacy hygiene** if wanted (the policy is worth having for npm/repo trust); **do not submit** to the Desktop Extensions directory — eligibility needs first-party API ownership or authorization/exception that a free third-party-data project realistically can't get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code (Opus 4.8) <noreply@anthropic.com>