### PR TITLE
fix(statusline): keep knockout ties live through extra time + penalties

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,8 @@ export {
   currentOrNextFixtureForTeam,
   fixturesInLiveWindow,
   LIVE_WINDOW_MS,
+  KNOCKOUT_EXTRA_TIME_MS,
+  liveWindowMsFor,
   groups,
   sanitizeBundledFixture,
 } from './schedule';

--- a/packages/core/src/schedule.ts
+++ b/packages/core/src/schedule.ts
@@ -92,10 +92,30 @@ export function nextFixtureForTeam(
   );
 }
 
-/** A fixture is potentially live from kickoff until ~kickoff + 140 min. */
+/**
+ * A group/regular fixture is potentially live from kickoff until ~kickoff + 140
+ * min (90' + half-time + stoppage).
+ */
 export const LIVE_WINDOW_MS = 140 * 60_000;
 
-/** Fixtures whose live window contains `now` (cheap, static — no network). */
+/**
+ * Extra allowance for knockout matches, which can go to extra time (+30') and a
+ * penalty shootout, running to ~kickoff + 190 min — well past LIVE_WINDOW_MS.
+ * Without it the statusline refresher stops polling at kickoff+140min and the
+ * cache goes stale mid-match, so a knockout tie still level after 90' (in ET or
+ * penalties) silently drops off the statusline while it's still being played.
+ * Numerically matches the slack `marketFixtureForTeam` already applies (live.ts).
+ */
+export const KNOCKOUT_EXTRA_TIME_MS = 60 * 60_000;
+
+/** Live-window length for a fixture — longer for knockout (extra time + penalties). */
+export function liveWindowMsFor(m: Match): number {
+  return m.stage === 'GROUP' || m.stage === 'FRIENDLY'
+    ? LIVE_WINDOW_MS
+    : LIVE_WINDOW_MS + KNOCKOUT_EXTRA_TIME_MS;
+}
+
+/** Fixtures whose (stage-aware) live window contains `now` (cheap, static — no network). */
 export function fixturesInLiveWindow(
   now = Date.now(),
   fixtures: Match[] = SCHEDULE,
@@ -103,7 +123,7 @@ export function fixturesInLiveWindow(
   return fixtures
     .filter((m) => {
       const k = Date.parse(m.kickoff);
-      return now >= k && now <= k + LIVE_WINDOW_MS;
+      return now >= k && now <= k + liveWindowMsFor(m);
     })
     .sort(byKickoff);
 }
@@ -123,7 +143,7 @@ export function currentOrNextFixtureForTeam(
   const nowMs = from.getTime();
   const inPlay = fixturesByTeam(code, opts.fixtures ?? SCHEDULE).find((m) => {
     const k = Date.parse(m.kickoff);
-    return nowMs >= k && nowMs <= k + LIVE_WINDOW_MS;
+    return nowMs >= k && nowMs <= k + liveWindowMsFor(m);
   });
   return inPlay ?? nextFixtureForTeam(code, opts);
 }

--- a/packages/core/test/schedule.test.ts
+++ b/packages/core/test/schedule.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { fixturesByDate, sanitizeBundledFixture, type Match } from '../src/index';
+import {
+  fixturesByDate,
+  fixturesInLiveWindow,
+  KNOCKOUT_EXTRA_TIME_MS,
+  LIVE_WINDOW_MS,
+  liveWindowMsFor,
+  sanitizeBundledFixture,
+  type Match,
+  type Stage,
+} from '../src/index';
 
 function fx(id: string, kickoff: string): Match {
   return {
@@ -13,6 +22,10 @@ function fx(id: string, kickoff: string): Match {
     status: 'SCHEDULED',
     updatedAt: '2026-06-01T00:00Z',
   };
+}
+
+function fxStage(id: string, kickoff: string, stage: Stage): Match {
+  return { ...fx(id, kickoff), stage, group: stage === 'GROUP' ? 'D' : undefined };
 }
 
 // A kickoff at 01:00Z on the 13th is the evening of the 12th in the Americas.
@@ -41,6 +54,45 @@ describe('fixturesByDate — local-date grouping', () => {
         weekday: 'long',
       });
       expect(wd).toBe('Saturday');
+    }
+  });
+});
+
+describe('fixturesInLiveWindow — stage-aware window (extra time + penalties)', () => {
+  const kickoff = '2026-07-19T19:00:00Z';
+  const k = Date.parse(kickoff);
+  const finalMatch = fxStage('final', kickoff, 'F');
+  const groupMatch = fxStage('group', kickoff, 'GROUP');
+
+  it('keeps a knockout tie in-window through extra time (the statusline-went-dark bug)', () => {
+    // 150 min after kickoff: past the 140-min group window, inside the KO window.
+    // Before the fix this returned [] for the final → refresher stopped, cache
+    // went stale, statusline showed "⚽ —" while ET was still being played.
+    const at150 = k + 150 * 60_000;
+    expect(fixturesInLiveWindow(at150, [finalMatch]).map((m) => m.id)).toEqual(['final']);
+    // A group match at the same offset has already fallen out (unchanged behavior).
+    expect(fixturesInLiveWindow(at150, [groupMatch])).toEqual([]);
+  });
+
+  it('a knockout tie drops out only after ET + penalties (past ~kickoff + 200 min)', () => {
+    const at210 = k + 210 * 60_000;
+    expect(fixturesInLiveWindow(at210, [finalMatch])).toEqual([]);
+  });
+
+  it('both stages are in-window during regulation (kickoff + 100 min)', () => {
+    const at100 = k + 100 * 60_000;
+    expect(
+      fixturesInLiveWindow(at100, [finalMatch, groupMatch])
+        .map((m) => m.id)
+        .sort(),
+    ).toEqual(['final', 'group']);
+  });
+
+  it('liveWindowMsFor: 140 min for group/friendly, +extra time for every knockout stage', () => {
+    expect(liveWindowMsFor(groupMatch)).toBe(LIVE_WINDOW_MS);
+    expect(liveWindowMsFor(fxStage('fr', kickoff, 'FRIENDLY'))).toBe(LIVE_WINDOW_MS);
+    for (const s of ['R32', 'R16', 'QF', 'SF', '3P', 'F'] as const) {
+      expect(liveWindowMsFor(fxStage('x', kickoff, s))).toBe(LIVE_WINDOW_MS + KNOCKOUT_EXTRA_TIME_MS);
     }
   });
 });


### PR DESCRIPTION
## Problem

The statusline/hook live window is a flat **kickoff + 140 min** for every fixture (`LIVE_WINDOW_MS`, `core/schedule.ts`). A knockout match can run to **~kickoff + 190 min** (extra time + a penalty shootout). Past 140 min:

1. `liveWindowActive` (`refresh.ts`) goes false → `claudinho prompt` stops spawning the refresher,
2. the cache freezes and ages past `DISPLAY_STALE_MS` (5 min),
3. `liveMatchesFromCache` drops the stale match → statusline shows `⚽ —`, hook goes empty — **while the match is still being played.**

**Observed live on the 2026 final:** 0–0 into extra time; at kickoff+140min (21:20Z) the statusline went dark even though the match ran on past 110'. `claudinho live` (network path, not window-gated) kept showing it correctly, which localized the bug to the static window.

## Fix

Make the live window **stage-aware**:
- group/friendly stay 140 min;
- knockout stages get `+KNOCKOUT_EXTRA_TIME_MS` (60 min → **200 min**), via a new `liveWindowMsFor(m)` helper.

Applied in `fixturesInLiveWindow` (drives both the statusline render fallback and the refresher cadence) and `currentOrNextFixtureForTeam`. The 200-min knockout window **numerically matches the slack `marketFixtureForTeam` already applies** (`live.ts`), so there's no drift between the two window notions.

## Verification

- New stage-aware regression tests in `core/test/schedule.test.ts` (KO tie still in-window at kickoff+150 min; a group match correctly not; drops out past ~200 min; `liveWindowMsFor` per stage).
- Full gate green: **core 259 / mcp 119 / cli 276**, typecheck + lint clean.
- **Verified against the live final:** the fixed build renders `⚽ 🇪🇸 1–0 🇦🇷 110'` where the shipped binary showed `⚽ —`.

## Notes

- **Not MCP-affecting** (no tool shape/description change) → no `server.json`/Registry work.
- **Cost:** a knockout match that ends in *regulation* keeps the refresher polling ~15 s cadence for up to ~60 min longer (until the 200-min window closes), each poll finding nothing live. Bounded, cheap, KO-stage only.

Co-Authored-By: Claude Code (Sonnet 5) <noreply@anthropic.com>