### PR TITLE
chore(biome): make the $schema install-relative so it cannot drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,10 @@ Claudinho surfaces the 2026 men's football tournament in developer environments:
 `./node_modules/@biomejs/biome/configuration_schema.json`, so it resolves to whatever version is
 installed and is correct by construction after any bump. This replaced a version-pinned
 `https://biomejs.dev/schemas/<version>/schema.json` URL that drifted on **six** consecutive bumps
-(Dependabot rewrites only the root `package.json`, never `biome.json`), each one turning CI red.
+(Dependabot rewrites only the root `package.json`, never `biome.json`). Each drift made Biome emit a
+*"configuration schema version does not match the CLI version"* diagnostic on every lint run — three
+of them (2.5.0 / 2.5.1 / 2.5.3) landed on `main` that way, since an info-level diagnostic fails
+nothing. Only from the guard test onward did drift become a red build, which is what CI then caught.
 `packages/core/test/biome-schema.test.ts` now guards the *shape*: it fails if anyone reintroduces a
 pinned URL, or if a Biome upgrade moves the bundled schema file. (If you ever do edit `biome.json`,
 hand-edit it — `biome migrate` reformats the whole config to tabs.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,11 +35,14 @@ Claudinho surfaces the 2026 men's football tournament in developer environments:
 - `pnpm -F @claudinho/core test` — operate on a single package
 - `pnpm release:qa` — pre-tag surface renderer (see "Release readiness")
 
-**Bumping `@biomejs/biome`?** Bump `biome.json`'s `$schema` URL to the *same* version in the
-same change. Dependabot only rewrites the root `package.json`, so the schema pin drifts and Biome
-then reports a schema-version mismatch on every lint run (it has drifted on three bumps: 2.5.2,
-2.5.3, 2.5.4). **Hand-edit the single line — `biome migrate` reformats the whole config to tabs.**
-Guarded by `packages/core/test/biome-schema.test.ts`, which fails CI when the two disagree.
+**Bumping `@biomejs/biome`?** Nothing to do — `biome.json`'s `$schema` points at
+`./node_modules/@biomejs/biome/configuration_schema.json`, so it resolves to whatever version is
+installed and is correct by construction after any bump. This replaced a version-pinned
+`https://biomejs.dev/schemas/<version>/schema.json` URL that drifted on **six** consecutive bumps
+(Dependabot rewrites only the root `package.json`, never `biome.json`), each one turning CI red.
+`packages/core/test/biome-schema.test.ts` now guards the *shape*: it fails if anyone reintroduces a
+pinned URL, or if a Biome upgrade moves the bundled schema file. (If you ever do edit `biome.json`,
+hand-edit it — `biome migrate` reformats the whole config to tabs.)
 
 ## Releasing
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "ignoreUnknown": true,

--- a/packages/core/test/biome-schema.test.ts
+++ b/packages/core/test/biome-schema.test.ts
@@ -17,15 +17,22 @@ import { describe, expect, it } from 'vitest';
  * version is installed, so it is correct by construction after any bump — no edit,
  * no guard to satisfy, nothing to forget. Editors (VS Code / Cursor) resolve a
  * relative `$schema` against the config file's own directory, so completions keep
- * working. Biome itself never reads `$schema` (it is editor metadata), so linting is
- * unaffected either way — including in a fresh clone before `pnpm install`, where the
- * path simply does not resolve yet.
+ * working.
+ *
+ * What Biome does with the value (measured, not assumed): it READS it and, when the
+ * value is a versioned `biomejs.dev` URL, compares that version against its own —
+ * that is the "configuration schema version does not match the CLI version" info
+ * diagnostic the old scheme emitted on every lint run. It does NOT dereference or
+ * fetch the value: pointing `$schema` at a path that does not exist produces no
+ * diagnostic at all. Hence both properties we want — a relative path gives Biome no
+ * version to compare (the mismatch class disappears), and a not-yet-installed
+ * node_modules lints cleanly in a fresh clone.
  *
  * These assertions therefore guard the SHAPE, not a version: nobody should quietly
  * reintroduce a pinned URL (that restores the drift class), and the file the path
  * names must actually exist (a Biome major could rename or relocate it — the one way
- * this scheme can still break, and it would otherwise fail silently, since only an
- * editor would ever notice).
+ * this scheme can still break, and, per the measurement above, it would fail SILENTLY:
+ * Biome says nothing, so only an editor losing completions would ever reveal it).
  */
 const ROOT = '../../../';
 const readRoot = (rel: string) =>

--- a/packages/core/test/biome-schema.test.ts
+++ b/packages/core/test/biome-schema.test.ts
@@ -23,10 +23,11 @@ import { describe, expect, it } from 'vitest';
  * value is a versioned `biomejs.dev` URL, compares that version against its own —
  * that is the "configuration schema version does not match the CLI version" info
  * diagnostic the old scheme emitted on every lint run. It does NOT dereference or
- * fetch the value: pointing `$schema` at a path that does not exist produces no
- * diagnostic at all. Hence both properties we want — a relative path gives Biome no
- * version to compare (the mismatch class disappears), and a not-yet-installed
- * node_modules lints cleanly in a fresh clone.
+ * fetch the value: with Biome installed, pointing `$schema` at a path that does not
+ * exist produces no diagnostic at all. So a relative path gives Biome no version to
+ * compare and the mismatch class disappears, while the unresolved path itself costs
+ * nothing. (This says nothing about a clone with no `node_modules` — there `pnpm
+ * lint` fails at `biome: command not found`, before any config is read.)
  *
  * These assertions therefore guard the SHAPE, not a version: nobody should quietly
  * reintroduce a pinned URL (that restores the drift class), and the file the path

--- a/packages/core/test/biome-schema.test.ts
+++ b/packages/core/test/biome-schema.test.ts
@@ -1,50 +1,64 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 /**
- * `biome.json` lives at the REPO ROOT and pins the config schema BY VERSION
- * (`https://biomejs.dev/schemas/<version>/schema.json`), but Dependabot only ever
- * bumps `@biomejs/biome` in the root `package.json` — it never touches biome.json.
- * The two then drift and Biome reports a schema-version mismatch on every lint run.
+ * `biome.json` lives at the REPO ROOT and points `$schema` at the schema shipped
+ * INSIDE the installed package (`./node_modules/@biomejs/biome/configuration_schema.json`)
+ * rather than at a version-pinned `https://biomejs.dev/schemas/<version>/schema.json`.
  *
- * This has now drifted on three separate bumps (2.5.2, 2.5.3, 2.5.4), each caught
- * by a human reading lint output after the fact. Guard it so CI catches the next
- * one instead — same escalation as the knockout-surface coverage test: when a bug
- * recurs, stop relying on review vigilance.
+ * Why: Dependabot only ever bumps `@biomejs/biome` in the root `package.json` — it
+ * never touches biome.json — so a version-pinned URL drifts on EVERY bump, and Biome
+ * then reports a schema-version mismatch on every lint run. That happened on six
+ * consecutive bumps (2.5.0 / 2.5.1 / 2.5.3 landed mismatched on main; 2.5.2 / 2.5.4 /
+ * 2.5.5 were caught and hand-patched on the PR branch first).
  *
- * Compared against the version DECLARED in package.json (not the resolved
- * node_modules copy) because that is exactly what Dependabot rewrites, and it
- * stays deterministic regardless of install layout.
+ * The relative path makes drift STRUCTURALLY IMPOSSIBLE: it resolves to whatever
+ * version is installed, so it is correct by construction after any bump — no edit,
+ * no guard to satisfy, nothing to forget. Editors (VS Code / Cursor) resolve a
+ * relative `$schema` against the config file's own directory, so completions keep
+ * working. Biome itself never reads `$schema` (it is editor metadata), so linting is
+ * unaffected either way — including in a fresh clone before `pnpm install`, where the
+ * path simply does not resolve yet.
+ *
+ * These assertions therefore guard the SHAPE, not a version: nobody should quietly
+ * reintroduce a pinned URL (that restores the drift class), and the file the path
+ * names must actually exist (a Biome major could rename or relocate it — the one way
+ * this scheme can still break, and it would otherwise fail silently, since only an
+ * editor would ever notice).
  */
+const ROOT = '../../../';
 const readRoot = (rel: string) =>
-  JSON.parse(readFileSync(new URL(`../../../${rel}`, import.meta.url), 'utf8'));
+  JSON.parse(readFileSync(new URL(`${ROOT}${rel}`, import.meta.url), 'utf8'));
 
-describe('biome.json $schema stays in lockstep with @biomejs/biome', () => {
+/** Expected value — one constant so the assertions and the failure text can't disagree. */
+const RELATIVE_SCHEMA = './node_modules/@biomejs/biome/configuration_schema.json';
+
+describe('biome.json $schema is install-relative, so it cannot drift', () => {
   const biomeConfig = readRoot('biome.json') as { $schema?: string };
   const rootPkg = readRoot('package.json') as { devDependencies?: Record<string, string> };
 
-  const declared = rootPkg.devDependencies?.['@biomejs/biome'];
-  /** Strip a leading range operator (^, ~, >=, …) to get the pinned version. */
-  const declaredVersion = declared?.replace(/^[\^~>=<\s]*/, '');
-  const schemaVersion = biomeConfig.$schema?.match(/schemas\/(\d+\.\d+\.\d+)\//)?.[1];
-
-  it('root package.json declares a concrete @biomejs/biome version', () => {
-    expect(declared).toBeTruthy();
-    expect(declaredVersion).toMatch(/^\d+\.\d+\.\d+$/);
+  it('root package.json still declares @biomejs/biome', () => {
+    expect(rootPkg.devDependencies?.['@biomejs/biome']).toBeTruthy();
   });
 
-  it('$schema is a versioned biomejs.dev schema URL', () => {
-    expect(biomeConfig.$schema).toMatch(
-      /^https:\/\/biomejs\.dev\/schemas\/\d+\.\d+\.\d+\/schema\.json$/,
-    );
-  });
-
-  it('$schema version matches the declared biome version (the drift guard)', () => {
+  it('$schema points into node_modules, NOT at a version-pinned URL', () => {
     expect(
-      schemaVersion,
-      `biome.json $schema is ${schemaVersion}, but package.json declares ` +
-        `@biomejs/biome ${declaredVersion}. Bump the $schema URL to match — ` +
-        'hand-edit the single line; `biome migrate` reformats the whole config to tabs.',
-    ).toBe(declaredVersion);
+      biomeConfig.$schema,
+      'biome.json $schema must stay install-relative. A versioned ' +
+        'https://biomejs.dev/schemas/<version>/schema.json URL reintroduces the drift ' +
+        'class: Dependabot bumps package.json but never biome.json, so the two fall ' +
+        `out of lockstep on every bump. Expected exactly: ${RELATIVE_SCHEMA}`,
+    ).toBe(RELATIVE_SCHEMA);
+  });
+
+  it('the schema file it names actually exists in the installed package', () => {
+    const abs = fileURLToPath(new URL(`${ROOT}${RELATIVE_SCHEMA.slice(2)}`, import.meta.url));
+    expect(
+      existsSync(abs),
+      `biome.json $schema names ${RELATIVE_SCHEMA}, but that file does not exist. ` +
+        'If a Biome upgrade moved it, update biome.json and RELATIVE_SCHEMA together; ' +
+        'if node_modules is simply absent, run `pnpm install` first.',
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Why

`biome.json` pinned the config schema **by version** (`https://biomejs.dev/schemas/<version>/schema.json`), but Dependabot rewrites only the root `package.json` — never `biome.json`. So the two fell out of lockstep on **every** bump, and Biome emitted a *"configuration schema version does not match the CLI version"* diagnostic on every lint run.

That happened **six consecutive times**. Three of them (2.5.0 / 2.5.1 / 2.5.3) landed **on main** — an info-level diagnostic fails nothing. The other three (2.5.2 / 2.5.4 / 2.5.5) were caught and hand-patched on the PR branch.

PR #89 added a guard so CI caught it instead of a human — but that only converted a silent diagnostic into a **red build that still needed a manual edit every single time**. This removes the class instead of the instance.

## What

```diff
-"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json"
+"$schema": "./node_modules/@biomejs/biome/configuration_schema.json"
```

The relative path resolves to **whatever version is installed**, so it is correct by construction after any bump — no edit, no guard to satisfy, nothing to forget.

The guard now checks the **shape**, not a version (its old assertions *required* a pinned URL, so they'd have failed the very fix):
- `$schema` must stay install-relative → nobody silently reintroduces a pinned URL and restores the drift class.
- The file it names **must exist** → a Biome major could rename or relocate it. That's the one remaining way this breaks, and per the measurement below it would fail **silently**.

## What Biome actually does with `$schema` (measured)

| scenario | result |
|---|---|
| versioned URL, version mismatched | `i The configuration schema version does not match the CLI version 2.5.5` |
| `$schema` → path that doesn't exist (Biome installed) | **no diagnostic at all** |

So Biome **reads** the value and compares versions when it's a versioned `biomejs.dev` URL, but never **dereferences/fetches** it. A relative path therefore gives Biome no version to compare — the mismatch class disappears — and the unresolved-path case costs nothing.

*(Scope note: this says nothing about a clone with no `node_modules`. There `pnpm lint` fails at `biome: command not found`, before any config is read — verified.)*

## Verified — by simulating the next bump

Identical experiment both ways: move `@biomejs/biome` to `^2.5.6`, install, leave `biome.json` **deliberately untouched**.

| | guard | lint |
|---|---|---|
| old (pinned URL) | ✗ 1 failed | `Found 1 info` — schema mismatch |
| **new (relative)** | **✓ 3 passed** | **clean, 147 files** |

Also: full gate green — build · typecheck · lint clean, **core 268 / mcp 119 / cli 290 = 677 tests**, `pnpm audit --prod` exit 0.

## Notes

- **Editors are fine.** VS Code / Cursor resolve a relative `$schema` against the config file's own directory. Completions keep working, and now always match the *installed* version rather than a hardcoded one.
- **`pnpm` symlinks resolve correctly** — `node_modules/@biomejs/biome` → `.pnpm/@biomejs+biome@<version>/…`, verified.
- **AGENTS.md updated**: the "bump the `$schema` URL in the same change" rule is retired, replaced with "nothing to do".
- Dev-tooling only — no runtime, no shipped package, no release implication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code (Opus 5) <noreply@anthropic.com>