### PR TITLE
docs(readme): document CLAUDINHO_NO_STAR opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ export CLAUDINHO_CURSOR_META=auto   # model + context % line under the score (re
 export CLAUDINHO_TEAM=MEX           # show only your team's match
 export CLAUDINHO_FLAGS=off          # 3-letter codes instead of flag emoji (already automatic in Warp)
 export CLAUDINHO_DEBUG=1            # print data-provider failure diagnostics to stderr
+export CLAUDINHO_NO_STAR=1          # suppress the occasional "star the repo" nudge
 ```
 
 > **Note:** Cursor's `beforeSubmitPrompt` hook doesn't yet reliably inject context into the


### PR DESCRIPTION
## Summary
- Document `CLAUDINHO_NO_STAR=1` in the README optional-env block (already supported by the CLI; was missing from user-facing docs).
- Clean maintainer take of the useful bit from closed spam PR #104 — no leading blank lines, no farm attribution.

## Test plan
- [ ] README optional-env section lists `CLAUDINHO_NO_STAR` beside the other knobs
- [ ] Confirm `CLAUDINHO_NO_STAR=1` still suppresses star nudges on interactive CLI output (existing tests cover this)

Co-Authored-By: Cursor (Grok 4.5) <cursoragent@cursor.com>