### PR TITLE
docs: document Claudinho's public footprint

### DIFF
--- a/PUBLIC_FOOTPRINT.md
+++ b/PUBLIC_FOOTPRINT.md
@@ -1,0 +1,107 @@
+# Claudinho Public Footprint
+
+A dated record of where Claudinho has been published, listed, discussed, reviewed, or
+presented. This exists both as project history and as a source of verified links for future
+posts, talks, release notes, and retrospectives.
+
+**Last reviewed:** August 14, 2026
+
+## How to read this record
+
+- **Current** means the page existed and mentioned Claudinho at the last review.
+- **Historical** means the appearance is verifiable, but it is no longer present on the
+  destination's current index or its current status is unclear.
+- **Automated** means a directory copied or enriched metadata from another registry. It is a
+  real backlink, but not an editorial endorsement, and its metadata may lag the repository.
+- Maintainer-authored launch posts and submissions are identified separately from independent
+  coverage and organic shares.
+
+Third-party pages change without notice. The repository, npm packages, and Official MCP Registry
+entry are the authoritative sources for current installation and feature details.
+
+## Canonical distribution
+
+| Surface | Status | Link | Notes |
+| --- | --- | --- | --- |
+| GitHub | Current | [arturogarrido/claudinho](https://github.com/arturogarrido/claudinho) | Source, issues, releases, and project history. |
+| npm CLI | Current | [@claudinho/cli](https://www.npmjs.com/package/@claudinho/cli) | Human-facing CLI, statusline, hook, and setup commands. |
+| npm MCP | Current | [@claudinho/mcp](https://www.npmjs.com/package/@claudinho/mcp) | Read-only stdio MCP server. |
+| npm core | Current | [@claudinho/core](https://www.npmjs.com/package/@claudinho/core) | Shared domain model and provider adapters. |
+| Official MCP Registry | Current | [io.github.arturogarrido/claudinho](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.arturogarrido/claudinho) | Version 0.9.4 was active and marked latest when reviewed. |
+
+## Registries and directories
+
+| Place | Status | Link | Notes |
+| --- | --- | --- | --- |
+| Smithery | Current | [Claudinho on Smithery](https://smithery.ai/servers/arturogarrido/claudinho) | Maintainer-published MCP bundle and listing. |
+| Glama | Current | [mcp-claudinho](https://glama.ai/mcp/servers/arturogarrido/claudinho) | A-rated listing. Generated tool metadata has occasionally lagged releases. |
+| MCP.so | Current | [Claudinho on MCP.so](https://mcp.so/servers/claudinho) | Maintainer-submitted listing. The overview is live; dynamic tool detection was incomplete when reviewed. |
+| cursor.directory | Current | [Claudinho plugin](https://cursor.directory/plugins/claudinho) | Cursor plugin and MCP listing, submitted June 18. |
+| Claude Marketplaces | Current, automated | [Claudinho MCP server](https://claudemarketplaces.com/mcp/arturogarrido/claudinho) | Registry-derived page. Its generated tool count may be stale. |
+| Enterprise DNA Directories | Current, automated | [arturogarrido/claudinho](https://enterprisedna.co/directories/mcp/arturogarrido-claudinho/) | Derived from the awesome-mcp-servers index; its star snapshot is historical. |
+| MCP Servers France | Current, automated | [arturogarrido/claudinho](https://www.mcp-servers.fr/server/server%20implementations-arturogarrido-claudinho) | Low-confidence mirror. Its version and connection metadata were incorrect when reviewed; use the canonical links above. |
+| Lulu | Current, automated | [Inbound listing report and response](https://github.com/arturogarrido/claudinho/issues/101) | Lulu indexed duplicate entries from PulseMCP and Smithery. Free factual indexing was accepted; the ads SDK proposal was declined and deduplication was requested. |
+
+## Curated repositories
+
+| Repository | Status | Link | Notes |
+| --- | --- | --- | --- |
+| awesome-claude-code | Current | [Repository](https://github.com/hesreallyhim/awesome-claude-code) / [submission #2027](https://github.com/hesreallyhim/awesome-claude-code/issues/2027) | Claudinho appears under statusline resources. The validated submission issue remained open when reviewed. |
+| awesome-mcp-servers | Historical | [Merged PR #7774](https://github.com/punkpeye/awesome-mcp-servers/pull/7774) | Accepted under Sports on June 15. The entry was no longer present in the current main README when reviewed on August 14. |
+
+## Independent coverage and organic shares
+
+These were published by people other than the maintainer.
+
+| Publisher | Date | Link | Notes |
+| --- | --- | --- | --- |
+| LinuxLinks | June 12, 2026 | [Claudinho - follow the World Cup from the terminal](https://www.linuxlinks.com/claudinho-follow-world-cup-terminal/) | Independent article covering the CLI, statusline, MCP server, offline schedule, localization, and share features. |
+| Nico Acosta | June 2026 | [LinkedIn share](https://www.linkedin.com/posts/acossta_github-arturogarridoclaudinho-2026-activity-7471214123213709313-WxwD) | Organic recommendation to people using Claude while following the tournament. |
+
+## Community and launch threads
+
+| Channel | Date | Link | Notes |
+| --- | --- | --- | --- |
+| Cursor Community | June 18, 2026 | [Built for Cursor thread](https://forum.cursor.com/t/claudinho-live-world-cup-scores-in-your-cursor-cli-statusline-a-read-only-mcp-server/163557) | Maintainer-authored integration post with substantive community replies. |
+| Hacker News | June 12, 2026 | [Show HN: A Claude Code statusline that shows live World Cup scores](https://news.ycombinator.com/item?id=48499159) | Maintainer-authored Show HN; 6 points and 1 comment. |
+| Product Hunt | June 14, 2026 | Link to recover | Maintainer launch; 6 votes. The stable public product URL was not recovered during this review. |
+
+## Maintainer build-in-public posts
+
+These links preserve the public narrative around the build. They are not independent coverage.
+
+### LinkedIn
+
+- [Launch: five days from idea to the tournament opener](https://www.linkedin.com/posts/arturogarrido_5-days-ago-this-repo-didnt-exist-today-activity-7470841392882253825-87eZ)
+- [Cursor Compile and Cursor CLI integration](https://www.linkedin.com/posts/arturogarrido_buildinpublic-devtools-worldcup2026-activity-7474251498269405184-NT06)
+- [First community contributor story](https://www.linkedin.com/posts/arturogarrido_something-magical-and-unexpected-happened-share-7476168070646886401-6uiH/)
+- [World Cup closing reflection](https://www.linkedin.com/posts/arturogarrido_vibinglavidaloca-ugcPost-7484840507261624321-6ees/)
+
+### X
+
+- [Round-of-32 bracket series](https://x.com/arturogarrido/status/2070405230190366956)
+- [Final group-stage bracket](https://x.com/arturogarrido/status/2071088545679499410)
+- [Quarterfinal bracket](https://x.com/arturogarrido/status/2075118756054155616)
+- [World Cup closing post](https://x.com/arturogarrido/status/2079073946822189068)
+
+## Events and presentations
+
+| Event | Date | Link | Notes |
+| --- | --- | --- | --- |
+| AGI House Agent Identity Build Day | 2026 | [Event page](https://app.agihouse.org/events/agent-identity-build-day) | Claudinho became the base for the +Claudinho secure multi-source signal demo. The project was selected as a finalist and presented live. |
+
+## Known links still to recover or confirm
+
+These appearances are part of the internal project record but do not yet have a verified,
+stable public detail URL in this file:
+
+- Product Hunt launch page.
+- PulseMCP auto-indexed listing.
+- mcp.directory submission outcome.
+- Cursor Marketplace review outcome.
+- AGI House project-submission page, if it remained public after the event.
+- Any Instagram posts or stories that should be preserved beyond their original lifetime.
+
+When adding an entry, record the original source, date, whether it was editorial or automated,
+and the date it was last verified. Do not call a submitted or scraped listing a feature or an
+endorsement.

--- a/PUBLIC_FOOTPRINT.md
+++ b/PUBLIC_FOOTPRINT.md
@@ -32,7 +32,7 @@ Footprint searches use the exact repository, package, and registry identifiers
 | npm CLI | Current | [@claudinho/cli](https://www.npmjs.com/package/@claudinho/cli) | Human-facing CLI, statusline, hook, and setup commands. |
 | npm MCP | Current | [@claudinho/mcp](https://www.npmjs.com/package/@claudinho/mcp) | Read-only stdio MCP server. |
 | npm core | Current | [@claudinho/core](https://www.npmjs.com/package/@claudinho/core) | Shared domain model and provider adapters. |
-| Official MCP Registry | Current | [io.github.arturogarrido/claudinho](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.arturogarrido/claudinho) | Machine-readable registry record. Version 0.9.4 was active and marked latest when reviewed. |
+| Official MCP Registry | Current | [io.github.arturogarrido/claudinho](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.arturogarrido/claudinho&version=latest) | Machine-readable latest-version record. Version 0.9.4 was active and marked latest when reviewed. |
 
 ## Registries and directories
 
@@ -45,7 +45,7 @@ Footprint searches use the exact repository, package, and registry identifiers
 | PulseMCP | Current, automated | [arturogarrido/claudinho](https://www.pulsemcp.com/servers/arturogarrido-claudinho) | Registry-derived listing, released June 6. Traffic and rank shown there are third-party estimates. |
 | Claude Marketplaces | Current, automated | [Claudinho MCP server](https://claudemarketplaces.com/mcp/arturogarrido/claudinho) | Registry-derived page. Its generated tool count may be stale. |
 | Enterprise DNA Directories | Current, automated | [arturogarrido/claudinho](https://enterprisedna.co/directories/mcp/arturogarrido-claudinho/) | Derived from the awesome-mcp-servers index; its star snapshot is historical. |
-| Developers Locker Room | Current | [Sports-tech directory index](https://devlocker.dev/whats-new) | Lists Claudinho under Soccer / Football; no stable per-project detail URL was found. |
+| Developers Locker Room | Current | [MCP directory index](https://devlocker.dev/mcp-servers) | Contains two records for the same project (`claudinho` and `claudinho-arturogarridoclaudinho`); count them as one appearance. No stable per-project detail URL was found. |
 | Lulu | Current, automated | [Inbound listing report and response](https://github.com/arturogarrido/claudinho/issues/101) | As of August 10, Lulu had indexed duplicate entries from PulseMCP and Smithery. Free factual indexing was accepted; the ads SDK proposal was declined and deduplication was requested. |
 
 ## Automated mirrors and scans
@@ -68,7 +68,7 @@ the source.
 | Repository | Status | Link | Notes |
 | --- | --- | --- | --- |
 | awesome-claude-code | Current | [Status Lines section](https://github.com/hesreallyhim/awesome-claude-code#status-lines) / [submission #2027](https://github.com/hesreallyhim/awesome-claude-code/issues/2027) | Claudinho appears under Status Lines even though the validated submission issue remained open when reviewed. |
-| awesome-mcp-servers | Current | [Sports section](https://github.com/punkpeye/awesome-mcp-servers#-sports) / [merged PR #7774](https://github.com/punkpeye/awesome-mcp-servers/pull/7774) | Accepted under Sports on June 15 and still present in the current main README. |
+| awesome-mcp-servers | Current | [Sports section](https://github.com/punkpeye/awesome-mcp-servers#-sports) / [merged PR #7774](https://github.com/punkpeye/awesome-mcp-servers/pull/7774) | Accepted under Sports on June 15 and verified in [`main` at `6c929cdf`](https://github.com/punkpeye/awesome-mcp-servers/blob/6c929cdf022f57cf954ab1b504cc266c0908373b/README.md#L3344) on August 18. |
 
 ## Independent coverage and organic shares
 
@@ -135,10 +135,10 @@ counted as coverage.
 - AGI House project-submission page, if it remained public after the event.
 - Any Instagram posts or stories that should be preserved beyond their original lifetime.
 
-Some current pages resist automated verification: MCP.so may return a Cloudflare 403,
-cursor.directory may return a Vercel 429 checkpoint, and AGI House serves a JavaScript-only shell.
-A bot wall is not evidence that a listing disappeared; check these pages in a browser before
-changing their status.
+Some current pages resist automated verification: MCP.so may return a Cloudflare 403, MCP Market
+and cursor.directory may return 429 checkpoints, and AGI House serves a JavaScript-only shell. A
+bot wall is not evidence that a listing disappeared; check these pages in a browser before changing
+their status.
 
 When adding an entry, record the original source, date, whether it was editorial or automated,
 and the date it was last verified. The header review date covers rows without their own verification

--- a/PUBLIC_FOOTPRINT.md
+++ b/PUBLIC_FOOTPRINT.md
@@ -4,7 +4,7 @@ A dated record of where Claudinho has been published, listed, discussed, reviewe
 presented. This exists both as project history and as a source of verified links for future
 posts, talks, release notes, and retrospectives.
 
-**Last reviewed:** August 14, 2026
+**Last reviewed:** August 18, 2026
 
 ## How to read this record
 
@@ -15,9 +15,14 @@ posts, talks, release notes, and retrospectives.
   real backlink, but not an editorial endorsement, and its metadata may lag the repository.
 - Maintainer-authored launch posts and submissions are identified separately from independent
   coverage and organic shares.
+- Unless a row gives a more specific date, its status was verified on the review date above.
 
 Third-party pages change without notice. The repository, npm packages, and Official MCP Registry
 entry are the authoritative sources for current installation and feature details.
+
+Footprint searches use the exact repository, package, and registry identifiers
+`arturogarrido/claudinho`, `@claudinho/*`, and `io.github.arturogarrido/claudinho`. Unscoped
+"Claudinho" results are excluded because the name also refers to unrelated people and projects.
 
 ## Canonical distribution
 
@@ -27,7 +32,7 @@ entry are the authoritative sources for current installation and feature details
 | npm CLI | Current | [@claudinho/cli](https://www.npmjs.com/package/@claudinho/cli) | Human-facing CLI, statusline, hook, and setup commands. |
 | npm MCP | Current | [@claudinho/mcp](https://www.npmjs.com/package/@claudinho/mcp) | Read-only stdio MCP server. |
 | npm core | Current | [@claudinho/core](https://www.npmjs.com/package/@claudinho/core) | Shared domain model and provider adapters. |
-| Official MCP Registry | Current | [io.github.arturogarrido/claudinho](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.arturogarrido/claudinho) | Version 0.9.4 was active and marked latest when reviewed. |
+| Official MCP Registry | Current | [io.github.arturogarrido/claudinho](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.arturogarrido/claudinho) | Machine-readable registry record. Version 0.9.4 was active and marked latest when reviewed. |
 
 ## Registries and directories
 
@@ -37,17 +42,33 @@ entry are the authoritative sources for current installation and feature details
 | Glama | Current | [mcp-claudinho](https://glama.ai/mcp/servers/arturogarrido/claudinho) | A-rated listing. Generated tool metadata has occasionally lagged releases. |
 | MCP.so | Current | [Claudinho on MCP.so](https://mcp.so/servers/claudinho) | Maintainer-submitted listing. The overview is live; dynamic tool detection was incomplete when reviewed. |
 | cursor.directory | Current | [Claudinho plugin](https://cursor.directory/plugins/claudinho) | Cursor plugin and MCP listing, submitted June 18. |
+| PulseMCP | Current, automated | [arturogarrido/claudinho](https://www.pulsemcp.com/servers/arturogarrido-claudinho) | Registry-derived listing, released June 6. Traffic and rank shown there are third-party estimates. |
 | Claude Marketplaces | Current, automated | [Claudinho MCP server](https://claudemarketplaces.com/mcp/arturogarrido/claudinho) | Registry-derived page. Its generated tool count may be stale. |
 | Enterprise DNA Directories | Current, automated | [arturogarrido/claudinho](https://enterprisedna.co/directories/mcp/arturogarrido-claudinho/) | Derived from the awesome-mcp-servers index; its star snapshot is historical. |
-| MCP Servers France | Current, automated | [arturogarrido/claudinho](https://www.mcp-servers.fr/server/server%20implementations-arturogarrido-claudinho) | Low-confidence mirror. Its version and connection metadata were incorrect when reviewed; use the canonical links above. |
-| Lulu | Current, automated | [Inbound listing report and response](https://github.com/arturogarrido/claudinho/issues/101) | Lulu indexed duplicate entries from PulseMCP and Smithery. Free factual indexing was accepted; the ads SDK proposal was declined and deduplication was requested. |
+| Developers Locker Room | Current | [Sports-tech directory index](https://devlocker.dev/whats-new) | Lists Claudinho under Soccer / Football; no stable per-project detail URL was found. |
+| Lulu | Current, automated | [Inbound listing report and response](https://github.com/arturogarrido/claudinho/issues/101) | As of August 10, Lulu had indexed duplicate entries from PulseMCP and Smithery. Free factual indexing was accepted; the ads SDK proposal was declined and deduplication was requested. |
+
+## Automated mirrors and scans
+
+These pages are real backlinks, but their copy, scores, installation advice, and security labels are
+generated from public metadata. None is an independent endorsement or a substitute for reviewing
+the source.
+
+| Place | Status | Link | Notes |
+| --- | --- | --- | --- |
+| MCPHQ | Current, automated + probe | [Claudinho MCP Server](https://mcphq.ai/mcp/arturogarrido-claudinho) | Nightly activity and registry verification. Generated setup and environment-variable advice may be stale. |
+| MCP.Pub | Current, automated profile | [Claudinho](https://mcp.pub/servers/claudinho/) | README-derived profile with a generated 7.0/10 score described by the site as an editorial verdict. |
+| MCP Market | Current, automated | [Claudinho](https://mcpmarket.com/server/claudinho) | README-derived profile. Its star and tool counts lagged the repository when reviewed. |
+| Claudeers | Current, automated | [claudinho](https://claudeers.com/claudinho) | Unclaimed README mirror. Its suggested `git clone` installation does not match the canonical `npx` path. |
+| Manifold | Current, automated scan | [Registry security manifest](https://manifest.manifold.security/mcp-servers/mcp-registry/arturogarrido/claudinho) | Registry-derived scan marked version 0.9.4 `Clean` on August 16. This is a point-in-time scanner result, not a security guarantee. |
+| npm.io | Current, automated | [CLI mirror](https://npm.io/package/@claudinho/cli) / [MCP mirror](https://npm.io/package/@claudinho/mcp) | Generic npm metadata and README mirrors. Use npm or the repository for canonical installation details. |
 
 ## Curated repositories
 
 | Repository | Status | Link | Notes |
 | --- | --- | --- | --- |
-| awesome-claude-code | Current | [Repository](https://github.com/hesreallyhim/awesome-claude-code) / [submission #2027](https://github.com/hesreallyhim/awesome-claude-code/issues/2027) | Claudinho appears under statusline resources. The validated submission issue remained open when reviewed. |
-| awesome-mcp-servers | Historical | [Merged PR #7774](https://github.com/punkpeye/awesome-mcp-servers/pull/7774) | Accepted under Sports on June 15. The entry was no longer present in the current main README when reviewed on August 14. |
+| awesome-claude-code | Current | [Status Lines section](https://github.com/hesreallyhim/awesome-claude-code#status-lines) / [submission #2027](https://github.com/hesreallyhim/awesome-claude-code/issues/2027) | Claudinho appears under Status Lines even though the validated submission issue remained open when reviewed. |
+| awesome-mcp-servers | Current | [Sports section](https://github.com/punkpeye/awesome-mcp-servers#-sports) / [merged PR #7774](https://github.com/punkpeye/awesome-mcp-servers/pull/7774) | Accepted under Sports on June 15 and still present in the current main README. |
 
 ## Independent coverage and organic shares
 
@@ -55,6 +76,7 @@ These were published by people other than the maintainer.
 
 | Publisher | Date | Link | Notes |
 | --- | --- | --- | --- |
+| SuperIsland | June 12, 2026 | [Live Football extension](https://github.com/shobhit99/SuperIsland/tree/main/Extensions/live-football) | Its README independently credits Claudinho as inspiration and identifies the same public ESPN data source. |
 | LinuxLinks | June 12, 2026 | [Claudinho - follow the World Cup from the terminal](https://www.linuxlinks.com/claudinho-follow-world-cup-terminal/) | Independent article covering the CLI, statusline, MCP server, offline schedule, localization, and share features. |
 | Nico Acosta | June 2026 | [LinkedIn share](https://www.linkedin.com/posts/acossta_github-arturogarridoclaudinho-2026-activity-7471214123213709313-WxwD) | Organic recommendation to people using Claude while following the tournament. |
 
@@ -64,7 +86,7 @@ These were published by people other than the maintainer.
 | --- | --- | --- | --- |
 | Cursor Community | June 18, 2026 | [Built for Cursor thread](https://forum.cursor.com/t/claudinho-live-world-cup-scores-in-your-cursor-cli-statusline-a-read-only-mcp-server/163557) | Maintainer-authored integration post with substantive community replies. |
 | Hacker News | June 12, 2026 | [Show HN: A Claude Code statusline that shows live World Cup scores](https://news.ycombinator.com/item?id=48499159) | Maintainer-authored Show HN; 6 points and 1 comment. |
-| Product Hunt | June 14, 2026 | Link to recover | Maintainer launch; 6 votes. The stable public product URL was not recovered during this review. |
+| Product Hunt | June 14, 2026 | [Claudinho](https://www.producthunt.com/products/claudinho) | Maintainer launch; 6 votes. |
 
 ## Maintainer build-in-public posts
 
@@ -88,20 +110,36 @@ These links preserve the public narrative around the build. They are not indepen
 
 | Event | Date | Link | Notes |
 | --- | --- | --- | --- |
-| AGI House Agent Identity Build Day | 2026 | [Event page](https://app.agihouse.org/events/agent-identity-build-day) | Claudinho became the base for the +Claudinho secure multi-source signal demo. The project was selected as a finalist and presented live. |
+| AGI House Agent Identity Build Day | June 27, 2026 | [Event page](https://app.agihouse.org/events/agent-identity-build-day) | Claudinho became the base for the +Claudinho secure multi-source signal demo. The project was selected as a finalist and presented live. |
 
-## Known links still to recover or confirm
+## Submitted, not published
 
-These appearances are part of the internal project record but do not yet have a verified,
-stable public detail URL in this file:
+These attempts are part of the distribution history. They are not live listings and should not be
+counted as coverage.
 
-- Product Hunt launch page.
-- PulseMCP auto-indexed listing.
-- mcp.directory submission outcome.
-- Cursor Marketplace review outcome.
+| Place | Submitted | Link | Outcome at last review |
+| --- | --- | --- | --- |
+| Cline MCP Marketplace | June 11, 2026 | [Submission #1773](https://github.com/cline/mcp-marketplace/issues/1773) | Still open with no comments. |
+| Cursor Marketplace | June 18, 2026 | [Marketplace](https://cursor.com/marketplace) | No public Claudinho listing found as of August 18. The repository's plugin manifest remains usable independently of Marketplace acceptance. |
+| mcp.directory | July 2, 2026 | [Directory](https://mcp.directory/) | No public Claudinho listing found as of August 18. |
+
+## Historical or delisted pages
+
+| Place | Status | Link | Notes |
+| --- | --- | --- | --- |
+| MCP Servers France | Historical, automated | [Former detail URL](https://www.mcp-servers.fr/server/server%20implementations-arturogarrido-claudinho) | The old page now resolves to generic site chrome with no Claudinho content. While live, its version and connection metadata were incorrect. |
+| PitchHut | Historical, automated | [Former project URL](https://www.pitchhut.com/project/claudinho) | The June preview page is now a `Project not found` response. |
+
+## Links still to recover
+
 - AGI House project-submission page, if it remained public after the event.
 - Any Instagram posts or stories that should be preserved beyond their original lifetime.
 
+Some current pages resist automated verification: MCP.so may return a Cloudflare 403,
+cursor.directory may return a Vercel 429 checkpoint, and AGI House serves a JavaScript-only shell.
+A bot wall is not evidence that a listing disappeared; check these pages in a browser before
+changing their status.
+
 When adding an entry, record the original source, date, whether it was editorial or automated,
-and the date it was last verified. Do not call a submitted or scraped listing a feature or an
-endorsement.
+and the date it was last verified. The header review date covers rows without their own verification
+date. Do not call a submitted or scraped listing a feature or an endorsement.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,20 @@ Speaks `en` / `es` / `pt` / `fr`, with optional localized commentary flair (`¡G
 
 _Planned (not shipped yet):_ a desktop notifier and an AI pundit with a public accuracy scorecard.
 
+## Around the web
+
+Claudinho was independently covered by [LinuxLinks](https://www.linuxlinks.com/claudinho-follow-world-cup-terminal/),
+listed in the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.arturogarrido/claudinho),
+[Smithery](https://smithery.ai/servers/arturogarrido/claudinho),
+[Glama](https://glama.ai/mcp/servers/arturogarrido/claudinho),
+[MCP.so](https://mcp.so/servers/claudinho),
+[cursor.directory](https://cursor.directory/plugins/claudinho), and
+[awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code), and discussed in the
+[Cursor Community](https://forum.cursor.com/t/claudinho-live-world-cup-scores-in-your-cursor-cli-statusline-a-read-only-mcp-server/163557).
+
+See **[PUBLIC_FOOTPRINT.md](PUBLIC_FOOTPRINT.md)** for the full dated record, including community
+posts, historical listings, automated mirrors, and events.
+
 ## FAQ
 
 **Do I need an API key or account?** No. Nothing to sign up for; `npx` and done.

--- a/README.md
+++ b/README.md
@@ -168,13 +168,19 @@ _Planned (not shipped yet):_ a desktop notifier and an AI pundit with a public a
 
 ## Around the web
 
-Claudinho was independently covered by [LinuxLinks](https://www.linuxlinks.com/claudinho-follow-world-cup-terminal/),
-listed in the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.arturogarrido/claudinho),
+Independent coverage and organic attribution include
+[LinuxLinks](https://www.linuxlinks.com/claudinho-follow-world-cup-terminal/) and
+[SuperIsland's Live Football extension](https://github.com/shobhit99/SuperIsland/tree/main/Extensions/live-football).
+
+Claudinho is also listed in the
+[Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.arturogarrido/claudinho),
 [Smithery](https://smithery.ai/servers/arturogarrido/claudinho),
 [Glama](https://glama.ai/mcp/servers/arturogarrido/claudinho),
 [MCP.so](https://mcp.so/servers/claudinho),
-[cursor.directory](https://cursor.directory/plugins/claudinho), and
-[awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code), and discussed in the
+[cursor.directory](https://cursor.directory/plugins/claudinho),
+[awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code#status-lines), and
+[awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#-sports). The Cursor integration
+was also discussed in the
 [Cursor Community](https://forum.cursor.com/t/claudinho-live-world-cup-scores-in-your-cursor-cli-statusline-a-read-only-mcp-server/163557).
 
 See **[PUBLIC_FOOTPRINT.md](PUBLIC_FOOTPRINT.md)** for the full dated record, including community

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Independent coverage and organic attribution include
 [SuperIsland's Live Football extension](https://github.com/shobhit99/SuperIsland/tree/main/Extensions/live-football).
 
 Claudinho is also listed in the
-[Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.arturogarrido/claudinho),
+[Official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.arturogarrido/claudinho&version=latest),
 [Smithery](https://smithery.ai/servers/arturogarrido/claudinho),
 [Glama](https://glama.ai/mcp/servers/arturogarrido/claudinho),
 [MCP.so](https://mcp.so/servers/claudinho),


### PR DESCRIPTION
## Summary

- add a dated public record of Claudinho's canonical distribution, directories, curated repositories, independent coverage, community threads, social posts, and events
- distinguish editorial coverage, curated inclusions, maintainer submissions, automated mirrors and scans, historical pages, and unsuccessful submissions
- add a concise "Around the web" section to the README with a link to the complete record

## Why

Preserve the project's public history and provide verified links for future posts, talks, release notes, and retrospectives without presenting submitted, scraped, or machine-scored listings as endorsements.

## Impact

Documentation only. No package or runtime behavior changes.

## Validation

- `git diff --check`
- `pnpm lint`

Co-Authored-By: Codex (GPT-5) <noreply@openai.com>