### PR TITLE
docs: replace broken Smithery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm: @claudinho/mcp](https://img.shields.io/npm/v/@claudinho/mcp?label=%40claudinho%2Fmcp&color=cb3837)](https://www.npmjs.com/package/@claudinho/mcp)
 [![npm downloads](https://img.shields.io/npm/dm/@claudinho/cli?label=downloads&color=cb3837)](https://www.npmjs.com/package/@claudinho/cli)
 [![cursor.directory](https://img.shields.io/badge/cursor.directory-claudinho-0b0b0b)](https://cursor.directory/plugins/claudinho)
-[![smithery badge](https://smithery.ai/badge/arturogarrido/claudinho)](https://smithery.ai/servers/arturogarrido/claudinho)
+[![LightNow capabilities](https://lightnow.ai/badge/io.github.arturogarrido/claudinho)](https://lightnow.ai/servers/io.github.arturogarrido/claudinho)
 [![Glama: A](https://img.shields.io/badge/Glama-A-2ea043)](https://glama.ai/mcp/servers/arturogarrido/claudinho)
 [![node](https://img.shields.io/node/v/@claudinho/cli?color=5fa04e)](https://nodejs.org)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)


### PR DESCRIPTION
Replaces the broken Smithery badge with the LightNow capability badge.

- [LightNow entry](https://lightnow.ai/servers/io.github.arturogarrido/claudinho)
- [Badge variants and usage](https://docs.lightnow.ai/how-to/add-capability-badge/)

Validated as a valid SVG showing `9 T · 0 R · 2 P`; the linked listing resolves successfully.