### PR TITLE
chore: fix the dead Smithery badge + skip zod major-version PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,10 +35,21 @@ updates:
     # `Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')`).
     # Adopting TS 7 is a deliberate migration gated on that tooling, not a routine
     # bump. Minor/patch on the 5.x/6.x line still flow.
+    #
+    # zod majors are skipped: zod is a RUNTIME dep of @claudinho/mcp and the MCP
+    # SDK derives every tool's inputSchema/outputSchema from it. Measured on the
+    # 3.25 -> 4.5 bump (PR #112): tools/list changed by 710 lines -- every
+    # inputSchema lost `additionalProperties: false`, all `$ref`s were inlined,
+    # keys reordered -- i.e. an MCP-AFFECTING change (Registry republish, .mcpb
+    # rebuild, Smithery re-score) even though the test suite stayed green.
+    # Adopting zod 4 is a deliberate migration tied to an MCP-affecting release,
+    # not a routine bump. Minor/patch on the 3.x line still flow.
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "zod"
         update-types: ["version-update:semver-major"]
 
   # Keep the GitHub Actions used in CI up to date.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm: @claudinho/mcp](https://img.shields.io/npm/v/@claudinho/mcp?label=%40claudinho%2Fmcp&color=cb3837)](https://www.npmjs.com/package/@claudinho/mcp)
 [![npm downloads](https://img.shields.io/npm/dm/@claudinho/cli?label=downloads&color=cb3837)](https://www.npmjs.com/package/@claudinho/cli)
 [![cursor.directory](https://img.shields.io/badge/cursor.directory-claudinho-0b0b0b)](https://cursor.directory/plugins/claudinho)
-[![smithery badge](https://smithery.ai/badge/arturogarrido/claudinho)](https://smithery.ai/servers/arturogarrido/claudinho)
+[![Smithery: listed](https://img.shields.io/badge/Smithery-listed-5b3df5)](https://smithery.ai/servers/arturogarrido/claudinho)
 [![Glama: A](https://img.shields.io/badge/Glama-A-2ea043)](https://glama.ai/mcp/servers/arturogarrido/claudinho)
 [![node](https://img.shields.io/node/v/@claudinho/cli?color=5fa04e)](https://nodejs.org)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)


### PR DESCRIPTION
## What
Two small maintainer-config items surfaced by today's open-PR review:

1. **Dead Smithery badge fixed** (`README.md`). `smithery.ai/badge/arturogarrido/claudinho` returns **HTTP 500** in every form (with/without `@`, with `.svg`), while the listing page and registry API are healthy — so the README rendered a broken image. Replaced with a static shields.io badge linking to the listing (the Glama-badge pattern), labeled `listed` because that's the only claim a static badge can keep true. This is the real finding under PR #111, which instead proposed swapping in a third-party directory's own badge (declined per the inbound-outreach policy).
2. **Dependabot ignores zod majors** (`.github/dependabot.yml`). Measured PR #112 (zod 3.25→4.5) in an isolated worktree: `tools/list` changes by **710 lines** — every inputSchema loses `additionalProperties: false`, all `$ref`s inline, keys reorder — an **MCP-affecting** change by this repo's definition (Registry republish, `.mcpb` rebuild, Smithery re-score) even though all 146 mcp tests pass. Same treatment as the existing `@types/node` / `typescript` major ignores; the migration goes on the backlog as a deliberate change.

## Verified
- Static badge renders (shields.io); listing link unchanged.
- YAML is additive; no schedule/grouping changes.

Docs + config only — nothing ships, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)